### PR TITLE
Add claude-meta-changelog, git-utils, and gh-utils skills

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(./gradlew tasks:*)"
-    ],
-    "deny": [],
-    "ask": []
-  }
-}

--- a/.claude/skills/claude-meta-changelog/SKILL.md
+++ b/.claude/skills/claude-meta-changelog/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: claude-meta-changelog
+description: >
+  Log changes to Claude Code internal assets as structured MET-nnnn entries in `meta/`.
+  AUTOMATICALLY trigger — without waiting for an explicit user request — whenever the user's
+  prompt asks to create, modify, or delete any of: `CLAUDE.md`, `.claude/agents/`,
+  `.claude/skills/`, `.claude/commands/`, `.claude/settings.json`.
+  Also trigger when the user explicitly asks to backport or migrate a past change.
+---
+
+# Claude Meta Changelog Skill
+
+Maintains an audit trail of deliberate changes to Claude Code internal assets. Each change is
+captured as a separate Markdown file in `meta/`, indexed in `meta/README.md`.
+
+---
+
+## When to Trigger
+
+Fire **automatically** (as part of the same response that makes the change) whenever the user's
+prompt requests a change to any Claude Code internal asset:
+
+| Asset | Examples |
+|-------|---------|
+| `CLAUDE.md` | Add/edit/remove rules, instructions, context |
+| `.claude/agents/*.md` | Create, update, or delete a custom agent |
+| `.claude/skills/**` | Create, update, or delete a skill |
+| `.claude/commands/**` | Create, update, or delete a slash command |
+| `.claude/settings.json` | Change hooks, permissions, or other config |
+
+Also trigger when the user explicitly requests **backporting** — logging a past change
+retroactively. In that case, accept a user-supplied date/time instead of the current timestamp.
+
+Do **not** trigger for changes to project source code, build files, or any folder other than the
+Claude internal assets listed above.
+
+---
+
+## Entry ID Scheme
+
+Each entry is assigned a sequential `MET-nnnn` identifier:
+
+```
+Glob("meta/MET-*.md") → find highest nnnn → next = nnnn + 1
+If meta/ is empty or has no MET-*.md files → start at 0001
+```
+
+---
+
+## File Naming
+
+```
+meta/MET-nnnn_<slug>.md
+```
+
+- `<slug>` is auto-derived from the one-sentence summary
+- Lowercase, hyphen-separated, **max 25 characters** (truncate cleanly at a word boundary)
+- Example: `MET-0001_add-git-utils-skill.md`
+
+---
+
+## Entry Format
+
+Base every entry on `.claude/templates/changelog-entry.md`:
+
+```markdown
+---
+id: MET-nnnn
+date: YYYY-MM-DD HH:MM
+requested_by: <git username of the person who made the request>
+executed_by: <git username or "AI">
+---
+
+## Summary
+
+<One-sentence description of what changed.>
+
+## Purpose
+
+<AI-proposed interpretation of why this change was made — confirmed or edited by the user before writing.>
+
+## Affected Files
+
+- `<file or folder path>`
+
+## Original Prompt
+
+> <Verbatim copy of the user's prompt that triggered this change.>
+```
+
+**Field rules:**
+- `date` — on Windows/PowerShell run `Get-Date -Format "yyyy-MM-dd HH:mm"`; on the Bash tool run `date +"%Y-%m-%d %H:%M"`. For backports use the user-supplied date.
+- `requested_by` — git username of the human who wrote the prompt (run `git config user.name`)
+- `executed_by` — `AI` when Claude performed the change; git username when the human did it themselves; both names comma-separated when both were involved
+- `Original Prompt` — quoted verbatim, exactly as the user typed it
+
+---
+
+## Purpose Field: Propose and Confirm
+
+Do **not** silently write the Purpose. Instead:
+
+1. Draft a one-paragraph interpretation of *why* the change was requested (infer from context, task history, prior conversation)
+2. Present it to the user: *"Here's the purpose I'll log — want to adjust it before I write the entry?"*
+3. Wait for confirmation or edits, then write the final entry
+
+Skip the confirmation step only if the user has already stated the purpose explicitly in their prompt.
+
+---
+
+## Index: meta/README.md
+
+After writing each entry, append a row to the index table in `meta/README.md`:
+
+```markdown
+| [MET-nnnn](MET-nnnn_<slug>.md) | YYYY-MM-DD | <requested_by> | <one-sentence summary> |
+```
+
+**Columns:** ID (linked) | Date | Who | Summary
+
+If `meta/README.md` does not exist, create it first:
+
+```markdown
+# Meta Changelog
+
+Audit trail of deliberate changes to Claude Code internal assets in this repository — rules (`CLAUDE.md`), agents (`.claude/agents/`), skills (`.claude/skills/`), commands (`.claude/commands/`), and configuration (`.claude/settings.json`).
+
+Each entry is a separate Markdown file named `MET-nnnn_<slug>.md`, based on the template at [`.claude/templates/changelog-entry.md`](../.claude/templates/changelog-entry.md).
+
+## Index
+
+| ID | Date | Who | Summary |
+|----|------|-----|---------|
+```
+
+---
+
+## Workflow
+
+```
+1. Detect that user's prompt touches a Claude internal asset
+2. Perform the requested change (write/edit the file)
+3. Glob("meta/MET-*.md") → determine next MET-nnnn
+4. Get timestamp (Get-Date on PowerShell, or date on Bash)
+5. run `git config user.name` → get requester name
+6. Draft Purpose paragraph → present to user for confirmation
+7. On confirmation: Write("meta/MET-nnnn_<slug>.md") using template
+8. Append row to meta/README.md index
+```
+
+---
+
+## Backport / Migration
+
+When the user says "log a past change" or "backport this to the changelog":
+
+1. Ask for (or accept from prompt): the original date/time, the affected files, the original prompt (if available)
+2. Use the user-supplied date in the `date` field instead of the current timestamp
+3. Note `[backported]` at the end of the Summary line
+4. Otherwise follow the same workflow
+
+---
+
+## Tips
+
+| Situation | Action |
+|-----------|--------|
+| Multiple files changed in one prompt | List all in Affected Files; one entry per prompt |
+| User's prompt is ambiguous about scope | Complete the change, then log what was actually modified |
+| Purpose is already stated in prompt | Use it directly; skip the confirmation step |
+| Skill creates `meta/` for the first time | Write `meta/README.md` before the first entry |

--- a/.claude/skills/gh-utils/SKILL.md
+++ b/.claude/skills/gh-utils/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: gh-utils
+description: Standardise GitHub operations in this repo by wrapping the gh CLI. Headline operation is creating a pull request from the current feature/<issue>-<slug> branch into develop; also covers viewing/listing PRs and checking PR/CI status. Delegates the actual gh commands to a spawned Haiku subagent. Use when asked to open a pull request, view/list PRs, or check PR status.
+allowed-tools: Agent Bash Read Grep
+---
+
+# gh-utils
+
+Wraps the `gh` CLI to make GitHub operations in this repo follow one convention. As with `git-utils`, the **main agent decides what to do** (open a PR, list PRs, check status) and drafts any PR content; a **spawned Haiku subagent runs the mechanical `gh` commands** and reports back (e.g. the created PR URL).
+
+**Boundary with `git-utils`:** `git-utils` owns local operations — branch, pull, commit, push. `gh-utils` owns GitHub-side operations — pull requests and other `gh` tasks. PR creation assumes the feature branch is already **pushed**; if it is not, hand off to `git-utils` for the push first, then create the PR here.
+
+## How execution works: spawn a Haiku subagent
+
+For every operation that runs `gh` commands, spawn a subagent on the **Haiku** model via the `Agent` tool:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  model: "haiku",
+  run_in_background: false,
+  description: "<short label>",
+  prompt: "<the exact gh command(s) to run, plus what to report back>"
+)
+```
+
+The main agent works out the operation and drafts any content (PR title/body) using the rules below, then gives the subagent a precise, self-contained task: the literal `gh` command(s) and the exact output to return (e.g. the PR URL). The subagent executes; it does not decide titles, bodies, or base branches. Run synchronously (`run_in_background: false`) and relay the result to the user.
+
+## Operations
+
+### 1. Create a pull request (headline)
+
+- Create a PR from the current **`feature/<issue>-<slug>`** branch into **`develop`** (this repo's integration branch; `develop`→`master` release merges are done separately).
+- Precondition: the branch is pushed to `origin` with upstream set. If not, hand off to `git-utils` to push first.
+- The main agent drafts the **title** (concise, imperative) and the **body** (what changed and why; reference the GitHub issue number for issue-driven work, e.g. `Closes #142`). The body ends with the required generated-with trailer (per environment conventions):
+  ```
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  ```
+- Subagent command (typical):
+  ```
+  gh pr create --base develop --head feature/<issue>-<slug> --title "<title>" --body "<body>"
+  ```
+  Report the created PR URL. If a PR already exists for the branch, report that instead of creating a duplicate.
+
+### 2. View / list PRs
+
+- View the current branch's PR or a specific one:
+  ```
+  gh pr view [<number>] [--web]
+  gh pr list
+  ```
+  Report the PR summary or the list.
+
+### 3. Check PR / CI status
+
+- Check the current PR's checks and status:
+  ```
+  gh pr checks [<number>]
+  gh pr status
+  ```
+  Report pass/fail of checks and the review state.
+
+### 4. Other typical `gh` tasks (menu, not exhaustive)
+
+- `gh pr diff [<number>]` — inspect the PR diff.
+- `gh repo view [--web]` — open/inspect the repo.
+- `gh issue list` / `gh issue view <number>` — issues, when relevant.
+
+Treat this as a documented menu: run the specific `gh` command the task needs via the subagent, and report its output.
+
+## Guardrails
+
+- **Never merge or close a PR** (`gh pr merge`, `gh pr close`) without an explicit request from the user.
+- **Base branch is `develop`.** Confirm the PR targets `develop` unless the user names another base (e.g. a `develop`→`master` release PR into `master`).
+- **Do not create a PR from `develop` or `master` itself** — PRs come from a `feature/<issue>-<slug>` branch.
+- **Do not create a duplicate PR** — if one already exists for the branch, report it.
+- If a `gh` command fails (e.g. not authenticated, branch not pushed), report the failure and what would unblock it — do not retry blindly.

--- a/.claude/skills/git-utils/SKILL.md
+++ b/.claude/skills/git-utils/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: git-utils
+description: Standardise routine local git operations in this repo by wrapping the git CLI. Covers feature-branch creation as feature/<issue>-<slug>, rebase-only pulls, commit messages that follow this repo's domain-based convention with proper commit granularity (related changes in one commit, unrelated changes in separate commits), and push on demand. Delegates the actual git commands to a spawned Haiku subagent. Use when asked to create a feature branch, pull, commit, or push.
+allowed-tools: Agent Bash Read Grep
+---
+
+# git-utils
+
+Wraps the `git` CLI to make routine local version-control operations in this repo follow one convention. The **main agent decides what to do** (which operation, how to group commits, what the branch is called and how to phrase the commit); a **spawned Haiku subagent runs the mechanical git commands** and reports back. This keeps fast, deterministic git work off the main agent while the skill supplies the recipe and the guardrails.
+
+**Boundary with `gh-utils`:** `git-utils` owns local operations — branch, pull, commit, push. `gh-utils` owns GitHub-side operations — pull requests and other `gh` tasks. When a task needs both (e.g. "open a PR"), `git-utils` pushes the branch and hands off to `gh-utils` for the PR.
+
+## How execution works: spawn a Haiku subagent
+
+For every operation that runs git commands, spawn a subagent on the **Haiku** model via the `Agent` tool:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  model: "haiku",
+  run_in_background: false,
+  description: "<short label>",
+  prompt: "<the exact git commands to run, plus what to report back>"
+)
+```
+
+The main agent's job before spawning:
+1. Work out the operation and its parameters (branch name, commit message, commit grouping) using the rules below.
+2. Inspect state where a decision is needed (`git status --short`, `git diff`) — this can be done directly or handed to the subagent to report first.
+3. Give the subagent a precise, self-contained task: the literal commands to run and the exact output to return (e.g. the new branch name, the commit SHAs, the push result). The subagent executes; it does not make grouping, naming, or message decisions.
+
+Relay the subagent's result to the user. Run synchronously (`run_in_background: false`) so the result is available immediately.
+
+## Operations
+
+### 1. Create a feature branch — `feature/<issue>-<slug>`
+
+- Branch name is **`feature/<issue>-<slug>`**, matching this repo's existing branches (e.g. `feature/142-code-coverage-phase-1`, `feature/135-pipeline-dsl-parallel-execution`):
+  - `<issue>` is the GitHub issue number the work addresses. If there is no issue, omit it and use a plain `feature/<slug>` — but prefer an issue number when one exists.
+  - `<slug>` is a kebab-case, ASCII-lowercase descriptor of the change (e.g. `pipeline-dsl-parallel-execution`, `code-coverage-phase-1`).
+- Branch from an **up-to-date `develop`**, not from the current feature branch, unless the user explicitly asks to branch from somewhere else. `develop` is this repo's integration branch (feature PRs target `develop`; `develop`→`master` is the release merge).
+- Subagent commands (typical):
+  ```
+  git checkout develop
+  git pull --rebase
+  git checkout -b feature/<issue>-<slug>
+  ```
+  Report the created branch name. Upstream is set on first push (see §4).
+
+### 2. Pull — always rebase
+
+- Pull is **always** `git pull --rebase`. Never a merge-pull; do not create merge commits from pulling.
+  ```
+  git pull --rebase
+  ```
+- If the rebase hits conflicts, stop and report — do not attempt to auto-resolve. The user resolves, then the subagent continues with `git rebase --continue`.
+
+### 3. Commit — one commit per logical change
+
+- Commit messages follow this repo's convention (see `CLAUDE.md` → *Commit Message Guidelines*): describe what changed and which domain was affected. For changes in a domain directory, mention the domain (e.g. `compilers`, `processors`, `flows`, `infra`). Subject is concise and imperative; a body explains what and why when the change is non-trivial.
+  - Format example: `Update KickAssembleUseCase in compilers domain to support additional output formats`.
+- **All changes that belong to one logical change go into a single commit.** Do not split a coherent change across several commits.
+- **Two or more unrelated changes are committed separately** — one commit each. Before committing, inspect `git status --short` and `git diff`; if the working tree mixes unrelated changes, group the files by logical change and stage/commit each group on its own (`git add <group>` then `git commit`), repeating per group.
+- The main agent decides the grouping and message and passes them to the subagent as explicit `git add`/`git commit` command sets; the subagent does not decide what is "related".
+- Commit messages end with the repository's required trailers (per environment conventions):
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  Claude-Session: <session URL>
+  ```
+- Example subagent task for two unrelated changes:
+  ```
+  git add path/a1 path/a2
+  git commit -m "<message A + trailers>"
+  git add path/b1
+  git commit -m "<message B + trailers>"
+  ```
+  Report each commit SHA and subject.
+
+### 4. Push — on demand only
+
+- **Never push automatically** after a commit. Push only when the user explicitly asks.
+- On the **first** push of a branch, set upstream:
+  ```
+  git push -u origin feature/<issue>-<slug>
+  ```
+  Thereafter a plain `git push`. Report the push result (and the PR-creation URL git prints, if any).
+
+## Guardrails
+
+- **Never force-push** (`--force`/`--force-with-lease`) or **amend** (`--amend`) unless the user explicitly asks. If history needs rewriting, surface it and wait.
+- **Never commit unrelated changes together** — separate them per §3.
+- **Never push without an explicit request** (§4).
+- **Branch from `develop`** for new feature branches (§1), not from the current branch, unless told otherwise.
+- **Do not skip hooks** (`--no-verify`) or bypass signing unless the user asks.
+- If a git command fails, report the failure and stop — do not retry blindly or work around it.

--- a/.claude/templates/changelog-entry.md
+++ b/.claude/templates/changelog-entry.md
@@ -1,0 +1,22 @@
+---
+id: MET-nnnn
+date: YYYY-MM-DD HH:MM
+requested_by: <git username of the person who made the request>
+executed_by: <git username or "AI">
+---
+
+## Summary
+
+<One-sentence description of what changed.>
+
+## Purpose
+
+<Why this change was made — confirmed or edited by the user before writing.>
+
+## Affected Files
+
+- `<file or folder path>`
+
+## Original Prompt
+
+> <Verbatim copy of the user's prompt that triggered this change.>

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ gradle-app.setting
 # IDE files
 /.idea
 *.iml
+
+# Claude Code local (per-developer) settings
+.claude/settings.local.json

--- a/meta/MET-0001_port-claude-skills.md
+++ b/meta/MET-0001_port-claude-skills.md
@@ -1,0 +1,25 @@
+---
+id: MET-0001
+date: 2026-07-14 23:05
+requested_by: Maciej Małecki
+executed_by: AI
+---
+
+## Summary
+
+Port three skills — `claude-meta-changelog`, `git-utils`, and `gh-utils` — from the `maciejmalecki/research` repo, plus a changelog entry template.
+
+## Purpose
+
+Bring three domain-agnostic engineering skills from the sibling `maciejmalecki/research` repo into this Gradle plugin project — an audit-trail changelog for Claude internal assets, plus standardized local git and GitHub-PR wrappers — adapted to this repo's `develop` base branch, `feature/<issue>-<slug>` branch naming, and domain-based commit conventions.
+
+## Affected Files
+
+- `.claude/skills/claude-meta-changelog/SKILL.md`
+- `.claude/skills/git-utils/SKILL.md`
+- `.claude/skills/gh-utils/SKILL.md`
+- `.claude/templates/changelog-entry.md`
+
+## Original Prompt
+
+> port meta changelog first, then git and gh utils,

--- a/meta/README.md
+++ b/meta/README.md
@@ -1,0 +1,11 @@
+# Meta Changelog
+
+Audit trail of deliberate changes to Claude Code internal assets in this repository — rules (`CLAUDE.md`), agents (`.claude/agents/`), skills (`.claude/skills/`), commands (`.claude/commands/`), and configuration (`.claude/settings.json`).
+
+Each entry is a separate Markdown file named `MET-nnnn_<slug>.md`, based on the template at [`.claude/templates/changelog-entry.md`](../.claude/templates/changelog-entry.md).
+
+## Index
+
+| ID | Date | Who | Summary |
+|----|------|-----|---------|
+| [MET-0001](MET-0001_port-claude-skills.md) | 2026-07-14 | Maciej Małecki | Port claude-meta-changelog, git-utils, and gh-utils skills plus a changelog entry template |


### PR DESCRIPTION
Ports three domain-agnostic Claude Code skills from the `maciejmalecki/research` repo into this project, adapted to this repo's conventions.

## Skills added

- **claude-meta-changelog** — auto-logs changes to Claude internal assets (`CLAUDE.md`, `.claude/**`) as `MET-nnnn` audit entries under `meta/`.
- **git-utils** — wraps local git operations: `feature/<issue>-<slug>` branches from `develop`, rebase-only pulls, domain-based commit messages, push on demand. Delegates mechanical commands to a Haiku subagent.
- **gh-utils** — wraps `gh` for PRs into `develop`, PR listing, and CI status.

Also adds `.claude/templates/changelog-entry.md` and the first changelog entry, `meta/MET-0001`.

## Adaptations from source repo

- Base branch `develop` (not `main`).
- Branch naming `feature/<issue>-<slug>` (matches existing branches).
- Commit convention aligned with this repo's domain-based `CLAUDE.md` guidelines.

Generated with [Claude Code](https://claude.com/claude-code)
