### PR TITLE
Document flows Pipeline DSL capabilities in user manual

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -1,6 +1,7 @@
 = Change log
 
 1.8.0::
+* Documentation: Expand flows Pipeline DSL manual with full step reference, parallel-execution and change-detection sections (#178)
 * Processors: Add GoatTracker music processor support (#122)
 * Processors: Enhance PNG image processor step support (#121)
 * Processors: Improve SpritePad asset processor functionality (#119)

--- a/doc/index.adoc
+++ b/doc/index.adoc
@@ -1264,11 +1264,41 @@ The traditional `preprocess` section continues to be the recommended approach fo
 The Pipeline DSL complements this existing functionality rather than replacing it.
 ====
 
+This section covers:
+
+* <<Pipeline DSL Basics>> — the `flows { }` block and how to declare a flow
+* <<Step Types>> — every step type, with a full option reference and examples
+* <<Path Helpers>> — `from()` / `to()` and the command-step `useFrom()` / `useTo()`
+* <<Parallel Execution>> — how independent steps and flows run concurrently
+* <<Change Detection and Incremental Builds>> — when steps re-run and when they are skipped
+* <<Flow Dependencies>> — ordering flows with `dependsOn`
+* <<Task Naming and Build Integration>> — the Gradle tasks flows generate
+* <<Complete Example>> — an end-to-end pipeline
+
+All examples are shown for both the **Groovy** DSL (`build.gradle`) and the **Kotlin**
+DSL (`build.gradle.kts`). The two are equivalent; use whichever matches your build script.
+Enum values (such as `CpuType.MOS6510`) are imported from the plugin's packages — with the
+Kotlin DSL you may need an explicit `import` or a fully-qualified name.
+
 === Pipeline DSL Basics
 
-Pipelines are defined in the `flows` section of your `build.gradle` file:
+Pipelines are defined in the `flows` section of your build script. A flow groups a sequence of
+steps under a name and an optional description:
 
 [source,groovy]
+.build.gradle (Groovy)
+----
+flows {
+    flow("myFlow") {
+        description = "Optional description of what this flow does"
+
+        // Define pipeline steps here
+    }
+}
+----
+
+[source,kotlin]
+.build.gradle.kts (Kotlin)
 ----
 flows {
     flow("myFlow") {
@@ -1281,87 +1311,337 @@ flows {
 
 === Step Types
 
-The Pipeline DSL supports multiple step types, each tailored to a specific task:
+The Pipeline DSL supports multiple step types, each tailored to a specific task. Every step is
+declared inside a `flow { }` block by its builder method (`assembleStep`, `charpadStep`, …).
 
 ==== Assembly Step
 
-Compile assembly source code with symbol generation support:
+Compile assembly source code with Kick Assembler, with symbol generation support:
 
 [source,groovy]
+.build.gradle (Groovy)
 ----
 assembleStep("main") {
     from("src/main.asm")
     to("build/output/main.prg")
     cpu = CpuType.MOS6510
     generateSymbols = true
+    outputFormat = OutputFormat.PRG
     includePaths("lib/c64lib")
     define("VERSION", "1.0")
+    watchFiles("src/**/*.asm")
 }
 ----
 
-Properties::
-- `from(path)` / `from(vararg paths)` - Input assembly file(s)
-- `to(path)` / `to(vararg paths)` - Output file(s)
-- `cpu` - CPU type (e.g., `CpuType.MOS6510`)
-- `generateSymbols` - Generate symbol files for debugging
-- `includePaths(paths...)` - Add include directories
-- `define(name, value)` - Define preprocessor symbols
+[source,kotlin]
+.build.gradle.kts (Kotlin)
+----
+assembleStep("main") {
+    from("src/main.asm")
+    to("build/output/main.prg")
+    cpu = CpuType.MOS6510
+    generateSymbols = true
+    outputFormat = OutputFormat.PRG
+    includePaths("lib/c64lib")
+    define("VERSION", "1.0")
+    watchFiles("src/**/*.asm")
+}
+----
+
+[cols="1,3,1", options="header"]
+|===
+| Property | Description | Default
+
+| `from(path...)`      | Input assembly file(s). | —
+| `to(path...)`        | Output file(s). If omitted, output goes to `build/flows/{flow}/{step}`. | —
+| `cpu`                | CPU type: `MOS6502`, `MOS6510`, or `MOS65C02`. | `MOS6510`
+| `generateSymbols`    | Generate a symbol file for debugging. | `true`
+| `optimization`       | `AssemblyOptimization`: `NONE`, `SIZE`, or `SPEED`. | `SPEED`
+| `verbose`            | Verbose assembler output. | `false`
+| `outputFormat`       | `OutputFormat`: `PRG` or `BIN`. | `PRG`
+| `workDir`            | Working directory for the assembler. | `".ra"`
+| `includePaths(p...)` / `includePath(p)` | Add include (library) directories. | —
+| `define(name, value)` / `defines(pairs...)` | Define preprocessor symbols. | —
+| `srcDirs(dirs...)` / `srcDir(dir)`   | Source directories for file discovery. | —
+| `includes(pat...)` / `include(pat)`  | Include patterns for file discovery. | —
+| `excludes(pat...)` / `exclude(pat)`  | Exclude patterns for file discovery. | —
+| `watchFiles(pat...)` / `watchFile(pat)` | Additional files to watch for change detection (alias of `includeFiles`); e.g. sources your main file `#import`s. | —
+|===
+
+==== dasm Step
+
+Assemble sources with the https://dasm-assembler.github.io/[dasm] assembler:
+
+[source,groovy]
+.build.gradle (Groovy)
+----
+dasmStep("build") {
+    from("src/main.asm")
+    to("build/main.bin")
+    outputFormat(1)
+    define("TARGET", "c64")
+}
+----
+
+[source,kotlin]
+.build.gradle.kts (Kotlin)
+----
+dasmStep("build") {
+    from("src/main.asm")
+    to("build/main.bin")
+    outputFormat(1)
+    define("TARGET", "c64")
+}
+----
+
+[cols="1,3,1", options="header"]
+|===
+| Property | Description | Default
+
+| `from(path...)`      | Input source file(s). | —
+| `to(path...)`        | Output file(s). If omitted, output goes to `build/flows/{flow}/{step}`. | —
+| `outputFormat(n)`    | dasm output format (1–3). | `1`
+| `verboseness(n)`     | Verboseness level (0–4). | unset
+| `errorFormat(n)`     | Error format: `0`=MS, `1`=Dillon, `2`=GNU. | unset
+| `strictSyntax(b)`    | Enable strict syntax checking. | unset
+| `removeOnError(b)`   | Remove output file when errors occur. | unset
+| `symbolTableSort(n)` | Symbol table sort order: `0`=alphabetical, `1`=address. | unset
+| `listFile(path)`     | Emit a list file at `path`. | unset
+| `symbolFile(path)`   | Emit a symbol file at `path`. | unset
+| `workDir`            | Working directory for the assembler. | `".ra"`
+| `includePaths(p...)` / `includePath(p)` | Add include directories. | —
+| `define(name, value)` / `defines(pairs...)` | Define preprocessor symbols. | —
+| `srcDirs(dirs...)` / `srcDir(dir)`   | Source directories for file discovery. | `["."]`
+| `includes(pat...)` / `include(pat)`  | Include patterns for file discovery. | `["**/*.asm"]`
+| `excludes(pat...)` / `exclude(pat)`  | Exclude patterns for file discovery. | `[".ra/**/*.asm"]`
+| `additionalInputs(pat...)` / `additionalInput(pat)` | Extra input-file patterns to track as dependencies. | —
+|===
 
 ==== CharPad Step
 
-Process CharPad CTM files to extract charset, maps, tiles, and other graphical assets:
+Process CharPad CTM files to extract charset, maps, tiles, and other graphical assets. Each
+output type is a nested block that takes an `output` path and optional `start`/`end` byte
+range (maps use a `left`/`top`/`right`/`bottom` rectangle instead):
 
 [source,groovy]
+.build.gradle (Groovy)
 ----
-charpadStep("charset") {
-    from("src/charset.ctm")
-    charset { output = "build/charset.chr" }
-    map { output = "build/charset.map" }
+charpadStep("graphics") {
+    from("src/game.ctm")
     compression = CharpadCompression.NONE
+    tileSize = 8
+
+    charset { output = "build/charset.chr" }
+    charsetColours { output = "build/charset-colours.bin" }
+    tiles { output = "build/tiles.bin" }
+    tileColours { output = "build/tile-colours.bin" }
+    map {
+        output = "build/map.bin"
+        left = 0; top = 0; right = 40; bottom = 25
+    }
+    meta {
+        output = "build/charpad.asm"
+        namespace = "game"
+        includeVersion = true
+    }
 }
 ----
 
-Properties::
-- `from(path)` - Input CTM file
-- `charset { }` - Extract character set
-- `map { }` - Extract map data
-- `tiles { }` - Extract tile set
-- `tileColours { }` - Extract tile colors
-- `charsetAttributes { }` - Extract character attributes
-- Additional output options available for each type
+[source,kotlin]
+.build.gradle.kts (Kotlin)
+----
+charpadStep("graphics") {
+    from("src/game.ctm")
+    compression = CharpadCompression.NONE
+    tileSize = 8
+
+    charset { output = "build/charset.chr" }
+    charsetColours { output = "build/charset-colours.bin" }
+    tiles { output = "build/tiles.bin" }
+    tileColours { output = "build/tile-colours.bin" }
+    map {
+        output = "build/map.bin"
+        left = 0; top = 0; right = 40; bottom = 25
+    }
+    meta {
+        output = "build/charpad.asm"
+        namespace = "game"
+        includeVersion = true
+    }
+}
+----
+
+Step options::
+[cols="1,3,1", options="header"]
+|===
+| Property | Description | Default
+
+| `from(path...)`  | Input CTM file(s). | —
+| `compression`    | `CharpadCompression`: `NONE`, `RLE`, or `EXOMIZER`. | `NONE`
+| `exportFormat`   | `CharpadFormat`: `STANDARD`, `OPTIMIZED`, or `C64LIB`. | `STANDARD`
+| `tileSize`       | Tile size in characters. | `8`
+| `charsetOptimization` | Optimise the charset. | `true`
+| `generateMap` / `generateCharset` | Whether to generate map / charset data. | `true`
+| `ctm8PrototypeCompatibility` | CTM8 prototype compatibility mode. | `false`
+| `namespace` / `prefix` | Default metadata namespace / symbol prefix. | `""`
+| `includeVersion` / `includeMode` | Include version / mode in metadata. | `false`
+| `includeBgColours` / `includeCharColours` | Include background / char colours in metadata. | `true`
+|===
+
+Output blocks:: Each takes `output` plus an optional `start` (default `0`) / `end`
+(default `65536`) byte range: `charset`, `charsetAttributes`, `charsetColours`,
+`charsetMaterials`, `charsetScreenColours`, `tiles`, `tileTags`, `tileColours`,
+`tileScreenColours`. The `map` block instead takes `output` plus a `left`/`top` (default `0`)
+and `right`/`bottom` (default `65536`) rectangle. The `meta` block emits an assembler source of
+symbol definitions and accepts `output`, `namespace`, `prefix`, `includeVersion`,
+`includeBgColours`, `includeCharColours`, and `includeMode` (overriding the step-level defaults).
+
+Filters:: Any of the range/map output blocks can additionally apply a filter to the extracted
+bytes:
++
+--
+* `nybbler { loOutput = "..."; hiOutput = "..."; normalizeHi = true }` — splits each byte into
+its low and high nibble, writing them to separate outputs. `loOutput`/`hiOutput` may each be
+omitted to discard that half. `normalizeHi` (default `true`) shifts the high nibble down so
+`0xA0` becomes `0x0A`.
+* `interleaver { outputs = listOf("a.bin", "b.bin") }` — distributes bytes round-robin across
+the listed outputs (the input size must divide evenly by the number of outputs).
+--
++
+[source,kotlin]
+.Nybbler filter example (Kotlin)
+----
+charpadStep("split-charset") {
+    from("src/game.ctm")
+    charset {
+        nybbler {
+            loOutput = "build/charset-lo.chr"
+            hiOutput = "build/charset-hi.chr"
+        }
+    }
+}
+----
+
+[NOTE]
+====
+The generic `to(path)` and `metadata { }` methods are deprecated — use the dedicated output
+blocks (`charset { }`, `map { }`, `meta { }`, …) shown above.
+====
 
 ==== SpritePad Step
 
-Process SpritePad SPD files to extract sprite definitions:
+Process SpritePad SPD files (`.spr`) to extract sprite definitions. The `sprites` block takes an
+`output` path and an optional `start`/`end` sprite range:
 
 [source,groovy]
+.build.gradle (Groovy)
 ----
 spritepadStep("sprites") {
     from("src/sprites.spr")
-    sprites { output = "build/sprites.bin" }
+    format = SpriteFormat.MULTICOLOR
+    sprites {
+        output = "build/sprites.bin"
+        start = 0
+        end = 8
+    }
 }
 ----
 
-Properties::
-- `from(path)` - Input SPD file
-- `sprites { }` - Extract sprite data
-- `start` / `end` - Sprite range (optional)
+[source,kotlin]
+.build.gradle.kts (Kotlin)
+----
+spritepadStep("sprites") {
+    from("src/sprites.spr")
+    format = SpriteFormat.MULTICOLOR
+    sprites {
+        output = "build/sprites.bin"
+        start = 0
+        end = 8
+    }
+}
+----
+
+[cols="1,3,1", options="header"]
+|===
+| Property | Description | Default
+
+| `from(path...)`     | Input SPD (`.spr`) file(s). | —
+| `format`            | `SpriteFormat`: `HIRES` or `MULTICOLOR`. | `MULTICOLOR`
+| `optimization`      | `SpriteOptimization`: `NONE`, `SIZE`, or `SPEED`. | `SIZE`
+| `exportRaw`         | Export raw sprite data. | `true`
+| `exportOptimized`   | Export optimised sprite data. | `false`
+| `animationSupport`  | Enable animation support. | `false`
+| `sprites { output; start; end }` | Sprite output with optional range (`start` default `0`, `end` default `65536`). | —
+|===
+
+[NOTE]
+====
+The generic `to(path)` method is deprecated — use the `sprites { }` block instead.
+====
 
 ==== Image Step
 
-Process image files (PNG, etc.) into binary format:
+Process image files (PNG) into C64 graphics formats. An image step optionally applies
+transformations (each at most once, in a fixed order — cut, split, extend, flip, reduce
+resolution) and then writes `sprite` and/or `bitmap` outputs:
 
 [source,groovy]
+.build.gradle (Groovy)
 ----
 imageStep("background") {
     from("src/background.png")
-    to("build/background.img")
+    targetFormat = ImageFormat.KOALA
+    dithering = DitheringAlgorithm.FLOYD_STEINBERG
+
+    cut { left = 0; top = 0; width = 320; height = 200 }
+    reduceResolution { reduceX = 1; reduceY = 1 }
+
+    bitmap { output = "build/background.bin" }
 }
 ----
 
-Properties::
-- `from(path)` - Input image file
-- `to(path)` - Output binary file
+[source,kotlin]
+.build.gradle.kts (Kotlin)
+----
+imageStep("background") {
+    from("src/background.png")
+    targetFormat = ImageFormat.KOALA
+    dithering = DitheringAlgorithm.FLOYD_STEINBERG
+
+    cut { left = 0; top = 0; width = 320; height = 200 }
+    reduceResolution { reduceX = 1; reduceY = 1 }
+
+    bitmap { output = "build/background.bin" }
+}
+----
+
+Step options::
+[cols="1,3,1", options="header"]
+|===
+| Property | Description | Default
+
+| `from(path...)`        | Input image file(s) (PNG). | —
+| `targetFormat`         | `ImageFormat`: `KOALA`, `ART_STUDIO`, `HIRES_BITMAP`, or `MULTICOLOR_BITMAP`. | `KOALA`
+| `paletteOptimization`  | `PaletteOptimization`: `NONE`, `REDUCE_COLORS`, or `QUANTIZE`. | `REDUCE_COLORS`
+| `dithering`            | `DitheringAlgorithm`: `NONE`, `FLOYD_STEINBERG`, or `ORDERED`. | `FLOYD_STEINBERG`
+| `backgroundColor`      | Background colour index. | `0`
+| `transparencySupport`  | Enable transparency support. | `false`
+|===
+
+Transformations (each optional, applied in this order)::
+[cols="1,3", options="header"]
+|===
+| Block | Parameters
+
+| `cut { }`   | `left` (0), `top` (0), `width`, `height` — crop a region.
+| `split { }` | `width`, `height` — split into equally-sized sub-images (tiles).
+| `extend { }`| `newWidth`, `newHeight`, `fillColor` (default opaque black `Color(0,0,0,255)`) — enlarge the canvas.
+| `flip { }`  | `axis`: `Axis.X`, `Axis.Y`, or `Axis.BOTH` (default `Y`) — reflect the image.
+| `reduceResolution { }` | `reduceX` (1), `reduceY` (1) — scale down by the given factors.
+|===
+
+Outputs:: `sprite { output = "..." }` writes sprite-format data; `bitmap { output = "..." }`
+writes bitmap-format data. Both may be used in the same step.
 
 ==== GoatTracker Step
 
@@ -1375,50 +1655,161 @@ The syntax and behavior may change in future releases.
 Convert GoatTracker 2 music files (SNG format) to SID format for embedding in programs:
 
 [source,groovy]
+.build.gradle (Groovy)
 ----
 goattrackerStep("music") {
     from("src/music.sng")
     to("build/music.sid")
+    frequency = Frequency.PAL
     bufferedSidWrites = true
     sfxSupport = true
 }
 ----
 
-Properties::
-- `from(path)` - Input SNG file
-- `to(path)` - Output SID file
-- `bufferedSidWrites` - Enable SID register buffering for better quality
-- `sfxSupport` - Enable sound effects support
-- `disableOptimization` - Disable output optimization
-- `playerMemoryLocation` - Memory location for player code
-- `sidMemoryLocation` - SID chip base address
-- `storeAuthorInfo` - Include author information in output
-- `volumeChangeSupport` - Enable master volume control
-- `zeroPageLocation` - Zero page address for variables
-- `zeropageGhostRegisters` - Use zero page for internal variables
-- `executable` - Name of gt2reloc executable (default: "gt2reloc")
+[source,kotlin]
+.build.gradle.kts (Kotlin)
+----
+goattrackerStep("music") {
+    from("src/music.sng")
+    to("build/music.sid")
+    frequency = Frequency.PAL
+    bufferedSidWrites = true
+    sfxSupport = true
+}
+----
+
+[cols="1,3,1", options="header"]
+|===
+| Property | Description | Default
+
+| `from(path...)`          | Input SNG file(s). | —
+| `to(path...)`            | Output SID file(s). | —
+| `frequency`              | `Frequency`: `PAL` or `NTSC`. | `PAL`
+| `channels`               | Number of channels. | `3`
+| `optimization`           | Enable output optimisation. | `true`
+| `executable`             | Name of the `gt2reloc` executable. | `"gt2reloc"`
+| `bufferedSidWrites`      | Enable SID register buffering for better quality. | unset
+| `disableOptimization`    | Disable output optimisation. | unset
+| `playerMemoryLocation`   | Memory location for player code. | unset
+| `sfxSupport`             | Enable sound-effects support. | unset
+| `sidMemoryLocation`      | SID chip base address. | unset
+| `storeAuthorInfo`        | Include author information in output. | unset
+| `volumeChangeSupport`    | Enable master volume control. | unset
+| `zeroPageLocation`       | Zero-page address for variables. | unset
+| `zeropageGhostRegisters` | Use zero page for internal variables. | unset
+|===
+
+==== Exomizer Step
+
+Compress a binary with https://bitbucket.org/magli143/exomizer/wiki/Home[Exomizer]. The mode is
+selected by a `raw { }` or `mem { }` block; both accept the compression options as **property
+assignments**:
+
+[source,groovy]
+.build.gradle (Groovy)
+----
+exomizerStep("crunch") {
+    from("build/game.prg")
+    to("build/game.exo")
+    raw {
+        backwards = true
+        passes = 100
+    }
+}
+----
+
+[source,kotlin]
+.build.gradle.kts (Kotlin)
+----
+exomizerStep("crunch") {
+    from("build/game.prg")
+    to("build/game.exo")
+    raw {
+        backwards = true
+        passes = 100
+    }
+}
+----
+
+Step methods::
+- `from(path)` — input file to compress.
+- `to(path)` — output file.
+- `raw { }` — raw compression mode (the default). Accepts the common options below.
+- `mem { }` — memory (self-decrunching) mode. Accepts the common options plus `loadAddress` and `forward`.
+
+Common options (set inside `raw { }` or `mem { }`)::
+[cols="1,3,1", options="header"]
+|===
+| Option | Description | Default
+
+| `backwards`       | Compress backwards. | `false`
+| `reverse`         | Reverse the output. | `false`
+| `decrunch`        | Generate decrunch-compatible output. | `false`
+| `compatibility`   | Compatibility mode. | `false`
+| `speedOverRatio`  | Favour speed over compression ratio. | `false`
+| `encoding`        | Explicit encoding string. | unset
+| `skipEncoding`    | Skip encoding. | `false`
+| `maxOffset`       | Maximum offset. | `65535`
+| `maxLength`       | Maximum length. | `65535`
+| `passes`          | Number of optimisation passes. | `100`
+| `bitStreamTraits` | Bit-stream traits. | unset
+| `bitStreamFormat` | Bit-stream format. | unset
+| `controlAddresses`| Control addresses. | unset
+| `quiet`           | Suppress output. | `false`
+| `brief`           | Brief output. | `false`
+|===
+
+Memory-mode (`mem { }`) additional options::
+[cols="1,3,1", options="header"]
+|===
+| Option | Description | Default
+
+| `loadAddress` | Load address (or `"auto"`). | `"auto"`
+| `forward`     | Forward decrunching. | `false`
+|===
 
 ==== Command Step
 
-Execute external CLI commands:
+Execute an arbitrary external CLI command. Declare inputs and outputs (for change detection),
+then build the command line with positional parameters, flags, and options:
 
 [source,groovy]
+.build.gradle (Groovy)
 ----
 commandStep("compress", "exomizer") {
     from("build/output.prg")
     to("build/output.exo")
     param("sfx")
+    flag("-q")
     option("-o", "build/output.exo")
-    flag("--verbose")
 }
 ----
 
-Properties::
-- `from(path)` / `from(vararg paths)` - Input file(s)
-- `to(path)` / `to(vararg paths)` - Output file(s)
-- `param(value)` - Add positional parameter
-- `option(name, value)` - Add named option
-- `flag(name)` - Add boolean flag
+[source,kotlin]
+.build.gradle.kts (Kotlin)
+----
+commandStep("compress", "exomizer") {
+    from("build/output.prg")
+    to("build/output.exo")
+    param("sfx")
+    flag("-q")
+    option("-o", "build/output.exo")
+}
+----
+
+[cols="1,3", options="header"]
+|===
+| Method | Description
+
+| `from(path...)` / `to(path...)` | Declare input / output file(s).
+| `param(value)` / `params(values...)` | Add positional parameter(s).
+| `flag(f)` / `flags(f...)`       | Add boolean flag(s), e.g. `-q`.
+| `option(flag, value)` / `options(pairs...)` | Add an option with a value (two arguments).
+| `inputOption(flag, path)`       | Add `flag path` and register `path` as an input.
+| `outputOption(flag, path)`      | Add `flag path` and register `path` as an output.
+| `with(param...)` / `withOption(flag, value)` | Chainable variants of the above.
+| `useFrom(index)` / `useTo(index)` | Reference a declared input / output path — see <<Path Helpers>>.
+|===
 
 ==== Test Step
 
@@ -1459,11 +1850,96 @@ Each spec produces `+<name>.prg+`, `+<name>.vs+`, and `+<name>.specOut+` next to
 This test step is independent of the legacy `asmSpec`/`test` tasks — both mechanisms continue to work.
 ====
 
-=== Flow Dependencies
+=== Path Helpers
 
-Flows can depend on other flows to ensure correct execution order:
+Every step declares its inputs with `from(...)` and its outputs with `to(...)` (or, for
+processor steps, dedicated output blocks such as `charset { output = ... }`). Both accept a
+single path or a vararg list:
 
 [source,groovy]
+----
+from("a.asm", "b.asm")   // two inputs
+to("out.prg")            // one output
+----
+
+The **command step** additionally offers `useFrom(index)` and `useTo(index)` to reference a path
+you already declared, so a path is written exactly once (DRY) and reused as a command argument.
+Both default to index `0` and throw if no matching path was declared:
+
+[source,groovy]
+.build.gradle (Groovy)
+----
+commandStep("exomize", "exomizer") {
+    from("build/game-linked.bin")
+    to("build/game-linked.z.bin")
+    param("raw")
+    option("-o", useTo())     // -> "build/game-linked.z.bin"
+    param(useFrom())          // -> "build/game-linked.bin"
+}
+----
+
+[source,kotlin]
+.build.gradle.kts (Kotlin)
+----
+commandStep("exomize", "exomizer") {
+    from("build/game-linked.bin")
+    to("build/game-linked.z.bin")
+    param("raw")
+    option("-o", useTo())     // -> "build/game-linked.z.bin"
+    param(useFrom())          // -> "build/game-linked.bin"
+}
+----
+
+With multiple inputs or outputs, pass the zero-based index: `useFrom(1)`, `useTo(0)`, etc.
+
+=== Parallel Execution
+
+Within a flow, the plugin does not run steps in declaration order. Instead it derives the
+execution order **solely from the file input/output relationships between steps** — if step B's
+`from(...)` names a file that step A's `to(...)` produces, B runs after A. Steps with no such
+relationship are independent.
+
+Independent steps, and independent flows, run **concurrently** when Gradle's parallel mode is
+enabled — either with the `--parallel` command-line flag or `org.gradle.parallel=true` in
+`gradle.properties`. Parallelism inside a single processor (for example splitting work across
+outputs) uses Gradle's Workers API. No extra configuration is required; you only declare the
+`from`/`to` relationships and let Gradle schedule the work.
+
+The flow graph is validated at configuration time. A circular dependency between steps or flows,
+or a step that consumes an intermediate file nothing produces, fails the build before any task
+runs.
+
+=== Change Detection and Incremental Builds
+
+Flow steps are ordinary Gradle tasks with declared inputs and outputs, so Gradle's incremental
+build and up-to-date checking apply: a step is skipped (reported `UP-TO-DATE`) when its inputs
+and outputs are unchanged since the last run, and re-runs only when something it depends on
+changes.
+
+* **Inputs** are the paths you pass to `from(...)` (and, for processors, the source file);
+  **outputs** are the paths from `to(...)` or the output blocks.
+* When you omit `to(...)`, a step writes into a default output directory,
+  `build/flows/{flow}/{step}`.
+* Assembly steps additionally track *indirect* inputs — the sources your main file `#import`s /
+  includes. Register these with `watchFiles(...)` (or `includeFiles(...)`) so that editing an
+  imported library invalidates the step and you never get a stale build. The test step watches
+  the sources passed to its `from(...)` for the same reason.
+
+[NOTE]
+====
+`gradle clean` removes the `build/` directory. Steps that write outside `build/` (via an
+explicit `to(...)`) are not cleaned by `clean`; re-running the flow still refreshes them through
+normal up-to-date checking.
+====
+
+=== Flow Dependencies
+
+Beyond the automatic file-based ordering, a flow can explicitly depend on another flow with
+`dependsOn(...)`, ensuring the named flow(s) complete first. Explicit dependencies combine with
+the implicit artifact-based ones:
+
+[source,groovy]
+.build.gradle (Groovy)
 ----
 flows {
     flow("preprocessing") {
@@ -1484,13 +1960,68 @@ flows {
 }
 ----
 
-=== Complete Example
-
-[source,groovy]
+[source,kotlin]
+.build.gradle.kts (Kotlin)
 ----
 flows {
-    flow("build") {
-        description = "Complete game build pipeline"
+    flow("preprocessing") {
+        charpadStep("charset") {
+            from("src/game.ctm")
+            charset { output = "build/charset.chr" }
+        }
+    }
+
+    flow("compilation") {
+        dependsOn("preprocessing")
+
+        assembleStep("main") {
+            from("src/main.asm")
+            to("build/main.prg")
+        }
+    }
+}
+----
+
+`dependsOn` accepts one flow name or several (`dependsOn("a", "b")`).
+
+=== Task Naming and Build Integration
+
+Each flow and step becomes a Gradle task, following a fixed naming scheme:
+
+[cols="1,2", options="header"]
+|===
+| Task | Purpose
+
+| `flows` | Top-level aggregation task — runs *all* flows in dependency order (`./gradlew flows`).
+| `flow{FlowName}` | Aggregation task for one flow, e.g. `flowPreprocessing` for `flow("preprocessing")`.
+| `flow{FlowName}Step{StepName}` | A single step, e.g. `flowPreprocessingStepCharset`.
+|===
+
+Flow and step names are capitalised when embedded in the task name. All flow tasks are placed in
+the `flows` task group, so `./gradlew tasks --group flows` lists them.
+
+The `asm` (and `assemble`) task depends on the `flows` task, so any flow-based preprocessing runs
+automatically before assembly. You can also run flows on their own:
+
+[source,bash]
+----
+./gradlew flows                       # run every flow
+./gradlew flowPreprocessing           # run one flow
+./gradlew flowPreprocessingStepCharset  # run one step
+./gradlew asm                         # runs flows first, then assembles
+----
+
+=== Complete Example
+
+An end-to-end pipeline that preprocesses assets in one flow and compiles + packs in a second flow
+that depends on the first:
+
+[source,groovy]
+.build.gradle (Groovy)
+----
+flows {
+    flow("assets") {
+        description = "Convert graphics, sprites and music"
 
         charpadStep("graphics") {
             from("src/game.ctm")
@@ -1508,18 +2039,70 @@ flows {
             to("build/music.sid")
             bufferedSidWrites = true
         }
+    }
+
+    flow("game") {
+        description = "Compile and pack the game"
+        dependsOn("assets")
 
         assembleStep("main") {
             from("src/main.asm")
             to("build/game.prg")
             includePaths("lib/c64lib")
             generateSymbols = true
+            watchFiles("src/**/*.asm")
         }
 
-        commandStep("pack") {
+        exomizerStep("pack") {
             from("build/game.prg")
             to("build/game.exo")
-            param("sfx")
+            raw { backwards = true }
+        }
+    }
+}
+----
+
+[source,kotlin]
+.build.gradle.kts (Kotlin)
+----
+flows {
+    flow("assets") {
+        description = "Convert graphics, sprites and music"
+
+        charpadStep("graphics") {
+            from("src/game.ctm")
+            charset { output = "build/charset.chr" }
+            map { output = "build/map.bin" }
+        }
+
+        spritepadStep("sprites") {
+            from("src/sprites.spr")
+            sprites { output = "build/sprites.bin" }
+        }
+
+        goattrackerStep("music") {
+            from("src/soundtrack.sng")
+            to("build/music.sid")
+            bufferedSidWrites = true
+        }
+    }
+
+    flow("game") {
+        description = "Compile and pack the game"
+        dependsOn("assets")
+
+        assembleStep("main") {
+            from("src/main.asm")
+            to("build/game.prg")
+            includePaths("lib/c64lib")
+            generateSymbols = true
+            watchFiles("src/**/*.asm")
+        }
+
+        exomizerStep("pack") {
+            from("build/game.prg")
+            to("build/game.exo")
+            raw { backwards = true }
         }
     }
 }

--- a/plans/EXEC-0012_flows-user-documentation.md
+++ b/plans/EXEC-0012_flows-user-documentation.md
@@ -1,0 +1,73 @@
+# Execution Log: Extend User Documentation with Flows Capabilities
+
+**Exec ID**: EXEC-0012
+**Plan**: [PLAN-0012](PLAN-0012_flows-user-documentation.md)
+**Issue**: #178
+**Started**: 2026-07-18
+**Last Updated**: 2026-07-18
+**State**: in progress
+
+## 1. Execution Sessions
+
+### Session 1 — 2026-07-18
+
+- **Scope**: all (Phases 1–3, steps 1.1–3.3)
+- **Mode**: autonomous
+- **Outcome**: completed
+
+**Accuracy discipline adopted (from challenge review, verdict "sound with caveats").**
+Before writing, every documented method, property, default, and enum value was verified
+per-property against the source-of-truth classes, with `file:line`:
+- `AssembleStepBuilder.kt` — cpu=`MOS6510`, generateSymbols=true, optimization=`SPEED`,
+  outputFormat=`PRG`, workDir=".ra"; `includeFiles`/`watchFiles` aliases (`:125-142`).
+- `DasmStepBuilder.kt` — outputFormat=1, workDir=".ra"; defaults srcDirs `["."]`,
+  includes `["**/*.asm"]`, excludes `[".ra/**/*.asm"]` (`:186-188`).
+- `CharpadStepBuilder.kt` — compression=`NONE`, exportFormat=`STANDARD`, tileSize=8;
+  RangeOutputBuilder `output/start=0/end=65536`; `nybbler{loOutput/hiOutput/normalizeHi=true}`,
+  `interleaver{outputs}`; MapOutputBuilder `left/top/right=65536/bottom=65536`.
+- `SpritepadStepBuilder.kt` — format=`MULTICOLOR`, optimization=`SIZE`, exportRaw=true;
+  `sprites{output/start=0/end=65536}`.
+- `ImageStepBuilder.kt` — targetFormat=`KOALA`, paletteOptimization=`REDUCE_COLORS`,
+  dithering=`FLOYD_STEINBERG`; flip `axis=Axis.Y` default; extend `fillColor=Color(0,0,0,255)`;
+  reduceResolution `reduceX=1/reduceY=1`; outputs `sprite{output}`/`bitmap{output}`.
+- `ExomizerStepBuilder.kt` — `raw{}`/`mem{}` **property-assignment** blocks; maxOffset=65535,
+  maxLength=65535, passes=100, loadAddress="auto".
+- `GoattrackerStepBuilder.kt` — frequency=`PAL`, channels=3, optimization=true,
+  executable="gt2reloc".
+- `CommandStepBuilder.kt` — param/params/flag/flags/option/options/inputOption/outputOption/
+  with/withOption + `useFrom(index=0)` (`:191`)/`useTo(index=0)` (`:235`).
+- Enums (`flows/.../domain/config/ProcessorConfig.kt`, `shared/domain/{Axis,OutputFormat}.kt`):
+  CpuType{MOS6502,MOS6510,MOS65C02}, AssemblyOptimization{NONE,SIZE,SPEED},
+  CharpadCompression{NONE,RLE,EXOMIZER}, CharpadFormat{STANDARD,OPTIMIZED,C64LIB},
+  SpriteFormat{HIRES,MULTICOLOR}, SpriteOptimization{NONE,SIZE,SPEED}, Frequency{PAL,NTSC},
+  ImageFormat{KOALA,ART_STUDIO,HIRES_BITMAP,MULTICOLOR_BITMAP},
+  PaletteOptimization{NONE,REDUCE_COLORS,QUANTIZE}, DitheringAlgorithm{NONE,FLOYD_STEINBERG,ORDERED},
+  Axis{X,Y,BOTH}, OutputFormat{PRG,BIN}.
+- DSL entry (`FlowDsl.kt`): `flow`, `dependsOn`, `var description`, all step methods with both a
+  Kotlin `FlowBuilder.() -> Unit` and a Groovy `@DelegatesTo Closure` overload (DELEGATE_FIRST).
+- Task naming (`FlowTasksGenerator.kt`): `flow{Flow}Step{Step}` (`:83`), `flow{Flow}` (`:92`),
+  default output dir `build/flows/{flow}/{step}` (`:280`); parallel note (`:53,79-80`).
+
+| Step | Result | Verification | Notes |
+|------|--------|--------------|-------|
+| 1.1 | completed | `:doc:asciidoctor` BUILD SUCCESSFUL | Section reorganised with roadmap + xref list; Basics shown in both DSLs. |
+| 1.2 | completed | rendered; text from `FlowTasksGenerator.kt:53,79-80,114` | Parallel Execution subsection: file-derived ordering, `--parallel`, config-time graph validation. |
+| 1.3 | completed | rendered; from `BaseFlowStepTask` + `FlowTasksGenerator.kt:280,289-307` | Change Detection subsection: up-to-date checks, `watchFiles`, default `build/flows/{flow}/{step}`, clean note. |
+| 2.1 | completed | rendered; verified vs `DasmStepBuilder.kt`, `ExomizerStepBuilder.kt` | dasm + Exomizer added with full option tables; exomizer documented as property-assignment `raw{}`/`mem{}`. |
+| 2.2 | completed | rendered; verified vs `CharpadStepBuilder.kt`, `ImageStepBuilder.kt` | CharPad output blocks + nybbler/interleaver filters; Image transforms (cut/split/extend/flip/reduceResolution) + sprite/bitmap. |
+| 2.3 | completed | rendered; verified vs `AssembleStepBuilder.kt`, `SpritepadStepBuilder.kt`, `GoattrackerStepBuilder.kt`, `CommandStepBuilder.kt` | Assemble gains outputFormat/srcDirs/watchFiles table; Spritepad SPD `.spr` + props; Goattracker table; Command table; Test step left intact. |
+| 3.1 | completed | rendered; verified vs `CommandStepBuilder.kt:191,235` | Path Helpers: from/to varargs + command-step useFrom/useTo (both DSLs). |
+| 3.2 | completed | rendered; verified vs `FlowTasksGenerator.kt:83,92`, `RetroAssemblerPlugin` wiring | Task Naming table (`flows`/`flow{X}`/`flow{X}Step{Y}`) + `asm` depends on `flows`. |
+| 3.3 | completed | `:doc:asciidoctor` BUILD SUCCESSFUL; HTML 164.6 KB | Complete Example refreshed: two flows + `dependsOn`, both DSLs. |
+
+## 2. Deviations from Plan
+
+| # | Step | Deviation | Reason | Impact |
+|---|------|-----------|--------|--------|
+| 1 | 2.x / Phase 2 | Phase 2 step content (dasm/exomizer/charpad/image/assemble/spritepad/goattracker/command) was written as one contiguous rewrite of the Step Types region rather than as three temporally separate steps. | All nine steps edit the same `doc/index.adoc` section; writing them together kept the section coherent and avoided churn. | None — all planned content delivered; verification unchanged. |
+| 2 | — | Added a `CHANGES.adoc` entry (#178) under `1.8.0::`. | Plan Section 8 left it optional; it is the repo norm for user-facing manual changes, and the challenge review flagged omitting it. | One extra file changed beyond `doc/index.adoc`. |
+| 3 | — | Test Step subsection left unchanged (plan Step 2.3 said "leave intact"); it was already accurate and dual-example-appropriate. | Already well-documented at the prior location. | Test Step example remains Groovy-only, consistent with its callout style. |
+
+## 3. Follow-ups
+
+- None.

--- a/plans/EXEC-0012_flows-user-documentation.md
+++ b/plans/EXEC-0012_flows-user-documentation.md
@@ -5,7 +5,7 @@
 **Issue**: #178
 **Started**: 2026-07-18
 **Last Updated**: 2026-07-18
-**State**: in progress
+**State**: completed
 
 ## 1. Execution Sessions
 

--- a/plans/PLAN-0012_flows-user-documentation.md
+++ b/plans/PLAN-0012_flows-user-documentation.md
@@ -2,7 +2,7 @@
 
 **Plan ID**: PLAN-0012
 **Issue**: #178
-**Status**: accepted
+**Status**: implemented
 **Created**: 2026-07-18
 **Last Updated**: 2026-07-18
 
@@ -202,7 +202,7 @@ _None — all resolved._
 **Goal**: Establish the expanded section skeleton and document the two behaviours the issue
 explicitly names, so the highest-value gap is closed first and independently mergeable.
 
-1. **Step 1.1**: Reorganise the "Pipeline DSL (Experimental)" section outline.
+1. **Step 1.1** — [x] done: Reorganise the "Pipeline DSL (Experimental)" section outline.
    - Files: `doc/index.adoc`
    - Description: Keep the Experimental warning and the `preprocess`-is-default note. Establish
      subsection order: Basics → Step Types → Path Helpers → Parallel Execution → Change
@@ -210,7 +210,7 @@ explicitly names, so the highest-value gap is closed first and independently mer
      Complete Example. Add a short intro paragraph. (Per Q2, no diagrams — text + code only.)
    - Testing: `./gradlew asciidoctor` renders without errors.
 
-2. **Step 1.2**: Write the **Parallel Execution** subsection.
+2. **Step 1.2** — [x] done: Write the **Parallel Execution** subsection.
    - Files: `doc/index.adoc`
    - Description: Explain that step ordering within a flow is derived solely from file
      input/output relationships (`FlowTasksGenerator.setupFileDependencies`), that independent
@@ -220,7 +220,7 @@ explicitly names, so the highest-value gap is closed first and independently mer
      wording for consistency.
    - Testing: Renders; wording cross-checked against `FlowTasksGenerator.kt:52-54,78-80,125,329`.
 
-3. **Step 1.3**: Write the **Change Detection & Incremental Builds** subsection.
+3. **Step 1.3** — [x] done: Write the **Change Detection & Incremental Builds** subsection.
    - Files: `doc/index.adoc`
    - Description: Explain Gradle up-to-date checking via `@InputFiles`/`@OutputDirectory`
      (`BaseFlowStepTask`), that `inputs`/`outputs` (`from`/`to`) drive re-runs, that assembly
@@ -236,14 +236,14 @@ accurately — the issue's named requirements — even before every step is expa
 ### Phase 2: Step Type Reference (mergeable: complete, accurate step catalogue)
 **Goal**: Every step type documented accurately with a realistic example and properties list.
 
-1. **Step 2.1**: Add **`dasmStep`** and **`exomizerStep`** (currently undocumented).
+1. **Step 2.1** — [x] done: Add **`dasmStep`** and **`exomizerStep`** (currently undocumented).
    - Files: `doc/index.adoc`
    - Description: New subsections with Kotlin + Groovy examples and **full parameter tables**
      (Q1: exhaustive, including exomizer `raw{}`/`mem{}` modes and dasm output/verboseness/error
      options).
    - Testing: Methods/defaults verified against `DasmStepBuilder.kt`, `ExomizerStepBuilder.kt`.
 
-2. **Step 2.2**: Expand **`charpadStep`** and **`imageStep`**.
+2. **Step 2.2** — [x] done: Expand **`charpadStep`** and **`imageStep`**.
    - Files: `doc/index.adoc`
    - Description: Per Q4 — fully document CharPad output types and `nybbler{}`/`interleaver{}`
      filters, and the Image transformation pipeline (`cut/split/extend/flip/reduceResolution`)
@@ -251,7 +251,7 @@ accurately — the issue's named requirements — even before every step is expa
      `from/to`-only example. Kotlin + Groovy examples.
    - Testing: Verified against `CharpadStepBuilder.kt`, `ImageStepBuilder.kt`.
 
-3. **Step 2.3**: Correct and round out the remaining steps.
+3. **Step 2.3** — [x] done: Correct and round out the remaining steps.
    - Files: `doc/index.adoc`
    - Description: Verify/fix `assembleStep` (add `outputFormat`, `srcDirs`, `watchFiles`),
      `spritepadStep` (confirm SPD `.spr` input, format/optimization/exportRaw props),
@@ -263,13 +263,13 @@ accurately — the issue's named requirements — even before every step is expa
 ### Phase 3: Path Helpers, Task Naming, Examples & Polish (mergeable: finished section)
 **Goal**: Cover the remaining cross-cutting DSL surface and finalise examples.
 
-1. **Step 3.1**: Write the **Path Helpers** subsection.
+1. **Step 3.1** — [x] done: Write the **Path Helpers** subsection.
    - Files: `doc/index.adoc`
    - Description: Document `from()`/`to()` (single + vararg) generally, and the
      Command-step-specific `useFrom(index)`/`useTo(index)` with the DRY example from CLAUDE.md.
    - Testing: Verified against `CommandStepBuilder.kt:191,235`.
 
-2. **Step 3.2**: Write the **Task Naming & Build Integration** subsection.
+2. **Step 3.2** — [x] done: Write the **Task Naming & Build Integration** subsection.
    - Files: `doc/index.adoc`
    - Description: Document task names `flows`, `flow{Flow}`, `flow{Flow}Step{Step}`; that
      `./gradlew flows` runs all flows and `asm`/`assemble` depend on `flows`; and the
@@ -277,7 +277,7 @@ accurately — the issue's named requirements — even before every step is expa
      Execution Order".
    - Testing: Verified against `FlowTasksGenerator.kt:82,92,367` and `RetroAssemblerPlugin.kt:284-287`.
 
-3. **Step 3.3**: Refresh the **Complete Example** and add Kotlin/Groovy coverage per Q3.
+3. **Step 3.3** — [x] done: Refresh the **Complete Example** and add Kotlin/Groovy coverage per Q3.
    - Files: `doc/index.adoc`
    - Description: Update the end-to-end example to exercise multiple steps + a `dependsOn`,
      ensuring every method used exists. Provide it in both Kotlin (`.kts`) and Groovy (Q3).
@@ -319,7 +319,7 @@ accurately — the issue's named requirements — even before every step is expa
 - [x] This IS the documentation update (`doc/index.adoc`).
 - [ ] `README.md` — no change needed (it only links to the manual).
 - [ ] `CLAUDE.md` — no new pattern introduced; no change expected.
-- [ ] `CHANGES.adoc` — optionally add a changelog entry noting expanded flows documentation.
+- [x] `CHANGES.adoc` — added a changelog entry (#178) under `1.8.0::`.
 - [ ] Cross-check against `doc/arc42/building-blocks/flows.md` (internal) — no edit expected,
       read-only accuracy reference.
 
@@ -338,6 +338,8 @@ accurately — the issue's named requirements — even before every step is expa
 | 2026-07-18 | AI Agent | Initial draft created for issue #178 |
 | 2026-07-18 | AI Agent | Resolved Q1–Q4: full parameter tables for all steps, Kotlin+Groovy examples throughout, no diagrams. Propagated into requirements, Phase 2/3 steps, and risks. |
 | 2026-07-18 | AI Agent | Status → accepted (no unresolved questions). |
+| 2026-07-18 | AI Agent | Status → in progress; execution started (EXEC-0012). |
+| 2026-07-18 | AI Agent | All steps 1.1–3.3 completed. Rewrote the Pipeline DSL section of `doc/index.adoc` (all 9 steps documented with full tables + Kotlin/Groovy examples, parallel-execution/change-detection/task-naming subsections) and added a `CHANGES.adoc` entry (#178). `:doc:asciidoctor` renders clean (BUILD SUCCESSFUL). Status → implemented. See EXEC-0012 for the per-step log and deviations. |
 
 ---
 

--- a/plans/PLAN-0012_flows-user-documentation.md
+++ b/plans/PLAN-0012_flows-user-documentation.md
@@ -1,0 +1,344 @@
+# Feature: Extend User Documentation with Flows Capabilities
+
+**Plan ID**: PLAN-0012
+**Issue**: #178
+**Status**: accepted
+**Created**: 2026-07-18
+**Last Updated**: 2026-07-18
+
+## 1. Feature Description
+
+### Overview
+
+Original issue: *"extend user documentation with flow capabilities — Be rich in examples, note on parallel execution, change detection etc."*
+
+The flows (Pipeline DSL) subdomain has grown substantially, but the user manual's
+"Pipeline DSL (Experimental)" section (`doc/index.adoc:1248-1526`) is incomplete and in
+places inaccurate relative to the actual DSL surface. This plan rewrites and expands that
+section so users get an accurate, example-rich reference covering **every step type**, the
+**path helpers**, and — as the issue explicitly requests — the cross-cutting behaviours
+**parallel execution** and **change detection / incremental builds**, plus task naming and
+build integration.
+
+This is a **documentation-only** change: no production Kotlin code is modified. The single
+deliverable file is `doc/index.adoc` (published to GitHub Pages via
+`.github/workflows/documentation.yml` → `./gradlew asciidoctor`).
+
+### Requirements
+
+- Document all step types with realistic examples: `assembleStep`, `dasmStep` (currently
+  undocumented), `charpadStep` (expanded), `spritepadStep`, `imageStep` (expanded),
+  `goattrackerStep`, `exomizerStep` (currently undocumented), `commandStep`, `testStep`.
+- Document the `from()`/`to()` path helpers and the Command-step-specific `useFrom()`/`useTo()`.
+- Add a dedicated subsection on **parallel execution** (Gradle `--parallel`, file-derived
+  ordering, independent steps/flows run concurrently).
+- Add a dedicated subsection on **change detection / incremental builds** (Gradle up-to-date
+  checks, watched/additional inputs for assembly imports, default output dirs).
+- Document **flow dependencies** (`dependsOn` + implicit artifact-derived deps) and **task
+  naming** (`flows`, `flow{Flow}`, `flow{Flow}Step{Step}`) and build integration (`asm`
+  depends on `flows`).
+- Correct existing inaccuracies (e.g. `spritepadStep` input is `.spr`/SPD, CharPad output
+  richness, Image transformation pipeline).
+- Keep the existing "Experimental" framing and the note that `preprocess` remains the
+  recommended default.
+- Show both **Kotlin** (`build.gradle.kts`) and **Groovy** (`build.gradle`) DSL examples
+  **throughout** — parallel `[source,kotlin]` and `[source,groovy]` blocks for every step
+  (both DSLs are supported; decided Q3).
+- Provide **full parameter reference tables** for every step, including the CharPad
+  output/filter richness and the Image transformation pipeline (decided Q1/Q4).
+
+### Success Criteria
+
+- Every step builder listed in Section 3 has an accurate example and a properties list in the
+  manual.
+- `parallel execution` and `change detection` each have their own clearly titled subsection.
+- `./gradlew asciidoctor` renders `doc/index.adoc` without AsciiDoc errors, and the generated
+  HTML at `doc/build/docs/asciidoc/index.html` shows the new content.
+- No example in the manual references a DSL method or property that does not exist in the
+  current code (verified against the builder classes).
+
+## 2. Root Cause Analysis
+
+This is a feature (documentation gap), not a bug. Motivation: the flows subdomain shipped
+incrementally (PLAN-0010 spec64 support, PLAN-0011 Groovy DSL coverage) and the user manual
+was not kept in lockstep. Users cannot discover `dasmStep`, `exomizerStep`, the CharPad
+nybbler/interleaver filters, or the Image transformation pipeline, and there is no guidance on
+the two behaviours that most affect build correctness and speed — parallelism and incremental
+rebuilds.
+
+### Current State
+
+- `doc/index.adoc:1248-1526` ("Pipeline DSL (Experimental)") documents only:
+  `flows{}` basics, and steps `assembleStep`, `charpadStep` (minimal), `spritepadStep`,
+  `imageStep` (trivial `from/to` only), `goattrackerStep`, `commandStep`, `testStep`, plus a
+  Flow Dependencies subsection and a Complete Example.
+- Missing entirely: `dasmStep`, `exomizerStep`, CharPad output/filter richness, the Image
+  transformation blocks, `useFrom()/useTo()`, parallel execution, change detection, task
+  naming.
+- Two flow-related images already exist but are unreferenced: `doc/img/flow-arch.excalidraw.png`,
+  `doc/img/pipelines.png`.
+- The authoritative internal cross-check is `doc/arc42/building-blocks/flows.md`.
+
+### Desired State
+
+The "Pipeline DSL" section is a complete, accurate, example-rich user reference: every step
+type documented, both DSLs acknowledged, and dedicated subsections for parallel execution,
+change detection/incremental builds, flow dependencies, and task naming/build integration.
+
+### Gap Analysis
+
+Rewrite/expand a single AsciiDoc section. No code, no ports, no adapters. The "change" is
+purely in `doc/`. Verification is: builder classes are the source of truth for every method
+and default; `./gradlew asciidoctor` must render cleanly.
+
+## 3. Relevant Code Parts
+
+### Existing Components
+
+- **User manual (single source)**: `doc/index.adoc`
+  - Pipeline DSL section: `doc/index.adoc:1248-1526` — the region to rewrite/expand.
+  - AsciiDoc conventions in-file: `[source,groovy]` blocks, `Properties::` labeled lists,
+    `[WARNING]`/`[NOTE]` admonitions, callouts `<1>`.
+- **Asciidoctor build**: `doc/build.gradle.kts` — `org.asciidoctor.jvm.convert`, `sourceDir(".")`,
+  copies `img/`; **`doc/img/`** holds `flow-arch.excalidraw.png`, `pipelines.png`.
+- **Publish workflow**: `.github/workflows/documentation.yml` — on `master`, `./gradlew asciidoctor`
+  → deploy `doc/build/docs/asciidoc` to `gh-pages`.
+- **Internal accuracy cross-check**: `doc/arc42/building-blocks/flows.md`.
+
+### Source-of-truth builder classes (verify every documented method/default against these)
+
+All under `flows/adapters/in/gradle/src/main/kotlin/.../dsl/` unless noted:
+
+- **DSL entry/wiring**: `FlowsExtension.kt`, `FlowDsl.kt` (`flow()`, `FlowBuilder` step methods
+  + Groovy `Closure` overloads, `dependsOn`), registered in
+  `infra/gradle/.../RetroAssemblerPlugin.kt:116` (`flows` extension), `:245` (`wireFlows`),
+  `:284-287` (`asm`/`assemble` depend on `flows`).
+- **`AssembleStepBuilder.kt`** — cpu/generateSymbols/optimization/outputFormat/includePaths/
+  define/srcDirs/includes/excludes/watchFiles, default `workDir=".ra"`.
+- **`DasmStepBuilder.kt`** — dasm assembler (undocumented): outputFormat/verboseness/errorFormat/
+  strictSyntax/removeOnError/symbolTableSort/listFile/symbolFile, defaults srcDirs `["."]`,
+  includes `["**/*.asm"]`, excludes `[".ra/**/*.asm"]`.
+- **`CharpadStepBuilder.kt`** — compression/exportFormat/tileSize/metadata; output blocks
+  `charset/charsetAttributes/charsetColours/charsetMaterials/charsetScreenColours/tiles/
+  tileTags/tileColours/tileScreenColours`, `map{}`, `meta{}`; filters `nybbler{}`,
+  `interleaver{}`.
+- **`SpritepadStepBuilder.kt`** — format/optimization/exportRaw/exportOptimized/animationSupport;
+  `sprites{output;start;end}`. Input is SPD (`.spr`).
+- **`GoattrackerStepBuilder.kt`** — frequency/channels/optimization/executable + nullable tuning
+  options (already largely documented).
+- **`ImageStepBuilder.kt`** — targetFormat/paletteOptimization/dithering/backgroundColor/
+  transparencySupport; transforms `cut/split/extend/flip/reduceResolution`; outputs
+  `sprite{}`, `bitmap{}`.
+- **`ExomizerStepBuilder.kt`** — compression (undocumented): `raw{}`/`mem{}` modes, options
+  backwards/reverse/encoding/maxOffset/passes/loadAddress/etc.
+- **`CommandStepBuilder.kt`** — param/params/flag/flags/option/options/inputOption/outputOption/
+  with/withOption + `useFrom(index)`/`useTo(index)` (`:191`,`:235`).
+- **`TestStepBuilder.kt`** — spec/specs/from (already well documented at `doc/index.adoc:1424`).
+- **Parallelism / change detection / task naming**:
+  - `flows/adapters/in/gradle/.../FlowTasksGenerator.kt` — `setupFileDependencies` (`:329`),
+    parallel note (`:52-54`,`:78-80`), additional input registration (`:289-307`), default
+    output dir `build/flows/{flow}/{step}` (`:280`), task names `flow{Flow}Step{Step}` (`:82`),
+    `flow{Flow}` (`:92`), `flows` = `TASK_FLOWS` (`:367`), `validateFlowGraph()` (`:125`).
+  - `flows/adapters/in/gradle/.../tasks/BaseFlowStepTask.kt` — `@InputFiles @PathSensitive(RELATIVE)`,
+    `@OutputDirectory` (Gradle up-to-date checking).
+
+### Architecture Alignment
+
+- **Domain**: `flows` (documentation of), plus the `doc/` documentation asset.
+- **Use Cases / Ports / Adapters**: none created or modified — documentation only.
+- **CLAUDE.md rules**: no new module, so no `infra/gradle` `compileOnly` change; no code, so no
+  coverage impact. The CLAUDE.md arc42 rule is about architecture changes; this touches only the
+  user manual, but we will cross-check accuracy against `doc/arc42/building-blocks/flows.md`.
+
+### Dependencies
+
+- Asciidoctor toolchain (already configured in `doc/build.gradle.kts`); Ruby deps in `doc/Gemfile`.
+  No new dependency.
+
+## 4. Questions and Clarifications
+
+### Self-Reflection Questions
+
+- **Q**: Where do the new docs go — a new file or the existing manual?
+  - **A**: The existing manual `doc/index.adoc` is the only user-facing published document
+    (`asciidoctor` renders `doc/*.adoc` at the doc root; `documentation.yml` deploys it). New
+    flows docs extend the existing "Pipeline DSL (Experimental)" section in place.
+- **Q**: Is this code or docs?
+  - **A**: Docs only. No builder, port, or adapter changes. Verification is AsciiDoc rendering
+    plus manual accuracy cross-check against the builder classes.
+- **Q**: How is accuracy guaranteed?
+  - **A**: Every documented method/property/default is checked against the `*StepBuilder.kt`
+    classes and `FlowTasksGenerator.kt`; `doc/arc42/building-blocks/flows.md` is the internal
+    cross-reference.
+- **Q**: How is rendering verified locally?
+  - **A**: `./gradlew asciidoctor` (or `./gradlew :doc:asciidoctor`) → inspect
+    `doc/build/docs/asciidoc/index.html`.
+- **Q**: Depth for the undocumented and expanded steps? (Q1/Q4)
+  - **A**: **Full parameter tables** for every step, including `dasmStep`/`exomizerStep` and the
+    full CharPad output types + `nybbler{}`/`interleaver{}` filters and the Image transformation
+    pipeline (`cut/split/extend/flip/reduceResolution`, `sprite/bitmap`). Exhaustive reference is
+    preferred over a common-subset + source-pointer treatment.
+- **Q**: DSL language coverage? (Q3)
+  - **A**: **Both Kotlin and Groovy examples throughout** — every step gets parallel
+    `[source,kotlin]` (`build.gradle.kts`) and `[source,groovy]` (`build.gradle`) examples.
+- **Q**: Embed the existing flow diagrams? (Q2)
+  - **A**: **No** — keep the section text + code only for now; diagrams can be revisited later.
+
+### Unresolved Questions
+
+_None — all resolved._
+
+### Design Decisions
+
+- **Decision**: Single-file vs. split documentation.
+  - **Options**: (A) Expand `doc/index.adoc` in place; (B) create a new `doc/flows.adoc` included
+    into the manual.
+  - **Recommendation**: (A) Expand in place. The manual is a single rendered document and the
+    flows section already exists there; a split adds include wiring for no user benefit.
+
+## 5. Implementation Plan
+
+### Phase 1: Structure & Core Behaviours (mergeable: overview + parallel/change-detection docs)
+**Goal**: Establish the expanded section skeleton and document the two behaviours the issue
+explicitly names, so the highest-value gap is closed first and independently mergeable.
+
+1. **Step 1.1**: Reorganise the "Pipeline DSL (Experimental)" section outline.
+   - Files: `doc/index.adoc`
+   - Description: Keep the Experimental warning and the `preprocess`-is-default note. Establish
+     subsection order: Basics → Step Types → Path Helpers → Parallel Execution → Change
+     Detection & Incremental Builds → Flow Dependencies → Task Naming & Build Integration →
+     Complete Example. Add a short intro paragraph. (Per Q2, no diagrams — text + code only.)
+   - Testing: `./gradlew asciidoctor` renders without errors.
+
+2. **Step 1.2**: Write the **Parallel Execution** subsection.
+   - Files: `doc/index.adoc`
+   - Description: Explain that step ordering within a flow is derived solely from file
+     input/output relationships (`FlowTasksGenerator.setupFileDependencies`), that independent
+     steps and flows run concurrently under Gradle `--parallel` / `org.gradle.parallel=true`,
+     and that Workers API underpins processor parallelism. Note config-time validation of the
+     flow graph (circular deps fail the build). Reference the CLAUDE.md "Parallel Execution"
+     wording for consistency.
+   - Testing: Renders; wording cross-checked against `FlowTasksGenerator.kt:52-54,78-80,125,329`.
+
+3. **Step 1.3**: Write the **Change Detection & Incremental Builds** subsection.
+   - Files: `doc/index.adoc`
+   - Description: Explain Gradle up-to-date checking via `@InputFiles`/`@OutputDirectory`
+     (`BaseFlowStepTask`), that `inputs`/`outputs` (`from`/`to`) drive re-runs, that assembly
+     steps additionally watch `#import`ed sources (`registerAdditionalInputFiles`,
+     `watchFiles`), and the default output dir `build/flows/{flow}/{step}` when `to()` is
+     omitted. Add a short note referencing the known clean-behaviour quirk if relevant.
+   - Testing: Renders; cross-checked against `BaseFlowStepTask.kt` and
+     `FlowTasksGenerator.kt:280,289-307`.
+
+**Phase 1 Deliverable**: The section now explains parallel execution and incremental builds
+accurately — the issue's named requirements — even before every step is expanded. Mergeable.
+
+### Phase 2: Step Type Reference (mergeable: complete, accurate step catalogue)
+**Goal**: Every step type documented accurately with a realistic example and properties list.
+
+1. **Step 2.1**: Add **`dasmStep`** and **`exomizerStep`** (currently undocumented).
+   - Files: `doc/index.adoc`
+   - Description: New subsections with Kotlin + Groovy examples and **full parameter tables**
+     (Q1: exhaustive, including exomizer `raw{}`/`mem{}` modes and dasm output/verboseness/error
+     options).
+   - Testing: Methods/defaults verified against `DasmStepBuilder.kt`, `ExomizerStepBuilder.kt`.
+
+2. **Step 2.2**: Expand **`charpadStep`** and **`imageStep`**.
+   - Files: `doc/index.adoc`
+   - Description: Per Q4 — fully document CharPad output types and `nybbler{}`/`interleaver{}`
+     filters, and the Image transformation pipeline (`cut/split/extend/flip/reduceResolution`)
+     plus `sprite{}`/`bitmap{}` outputs, with parameter tables. Replace the trivial Image
+     `from/to`-only example. Kotlin + Groovy examples.
+   - Testing: Verified against `CharpadStepBuilder.kt`, `ImageStepBuilder.kt`.
+
+3. **Step 2.3**: Correct and round out the remaining steps.
+   - Files: `doc/index.adoc`
+   - Description: Verify/fix `assembleStep` (add `outputFormat`, `srcDirs`, `watchFiles`),
+     `spritepadStep` (confirm SPD `.spr` input, format/optimization/exportRaw props),
+     `goattrackerStep` (already good), `commandStep`, `testStep` (already good — leave intact).
+   - Testing: Each verified against its `*StepBuilder.kt`.
+
+**Phase 2 Deliverable**: A complete, accurate step catalogue. Mergeable independently of Phase 3.
+
+### Phase 3: Path Helpers, Task Naming, Examples & Polish (mergeable: finished section)
+**Goal**: Cover the remaining cross-cutting DSL surface and finalise examples.
+
+1. **Step 3.1**: Write the **Path Helpers** subsection.
+   - Files: `doc/index.adoc`
+   - Description: Document `from()`/`to()` (single + vararg) generally, and the
+     Command-step-specific `useFrom(index)`/`useTo(index)` with the DRY example from CLAUDE.md.
+   - Testing: Verified against `CommandStepBuilder.kt:191,235`.
+
+2. **Step 3.2**: Write the **Task Naming & Build Integration** subsection.
+   - Files: `doc/index.adoc`
+   - Description: Document task names `flows`, `flow{Flow}`, `flow{Flow}Step{Step}`; that
+     `./gradlew flows` runs all flows and `asm`/`assemble` depend on `flows`; and the
+     `dependsOn` + implicit artifact-derived dependency model. Align with CLAUDE.md "Task
+     Execution Order".
+   - Testing: Verified against `FlowTasksGenerator.kt:82,92,367` and `RetroAssemblerPlugin.kt:284-287`.
+
+3. **Step 3.3**: Refresh the **Complete Example** and add Kotlin/Groovy coverage per Q3.
+   - Files: `doc/index.adoc`
+   - Description: Update the end-to-end example to exercise multiple steps + a `dependsOn`,
+     ensuring every method used exists. Provide it in both Kotlin (`.kts`) and Groovy (Q3).
+   - Testing: Full `./gradlew asciidoctor` render; open `doc/build/docs/asciidoc/index.html`
+     and eyeball the flows section end-to-end.
+
+**Phase 3 Deliverable**: The complete, accurate, example-rich flows section. Mergeable.
+
+## 6. Testing Strategy
+
+### Unit Tests
+- None — documentation-only change; no production code touched.
+
+### Integration Tests
+- **Doc build**: `./gradlew asciidoctor` (or `:doc:asciidoctor`) must complete without AsciiDoc
+  syntax/rendering errors. This is the CI gate that `documentation.yml` runs on `master`.
+
+### Manual Testing
+- Open `doc/build/docs/asciidoc/index.html` and review the flows section for correct rendering
+  of admonitions, source blocks, callouts, and (if added) images.
+- **Accuracy pass**: for each documented method/property/default, confirm it exists in the
+  corresponding `*StepBuilder.kt` / `FlowTasksGenerator.kt`. This is the primary correctness
+  check for docs — no example may reference a non-existent DSL element.
+- Optionally cross-read `doc/arc42/building-blocks/flows.md` to ensure user docs and internal
+  docs agree.
+
+## 7. Risks and Mitigation
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Documented DSL drifts from actual builder API (wrong method/default) | Medium | Medium | Verify every example against `*StepBuilder.kt`; accuracy pass in Section 6 |
+| AsciiDoc syntax error breaks the published manual | Medium | Low | Run `./gradlew asciidoctor` before merge; CI renders on `master` |
+| Full parameter tables drift as the experimental DSL changes | Medium | Medium | Full tables were chosen deliberately (Q1); keep the "Experimental" framing, verify every property against the `*StepBuilder.kt` at write time, and treat the manual as regenerated when the DSL changes rather than hand-patched |
+| Kotlin + Groovy examples for every step doubles volume / risks the two drifting | Low | Medium | Keep examples minimal and mechanically parallel (same step, two source blocks); verify both compile-shape against the builders |
+| Section becomes too long/hard to navigate | Low | Medium | Clear subsection hierarchy; consider an overview diagram (Q2) |
+
+## 8. Documentation Updates
+
+- [x] This IS the documentation update (`doc/index.adoc`).
+- [ ] `README.md` — no change needed (it only links to the manual).
+- [ ] `CLAUDE.md` — no new pattern introduced; no change expected.
+- [ ] `CHANGES.adoc` — optionally add a changelog entry noting expanded flows documentation.
+- [ ] Cross-check against `doc/arc42/building-blocks/flows.md` (internal) — no edit expected,
+      read-only accuracy reference.
+
+## 9. Rollout Plan
+
+1. Merge the doc changes to `develop`, then to `master` via the normal flow.
+2. On push to `master`, `.github/workflows/documentation.yml` runs `./gradlew asciidoctor` and
+   deploys to `gh-pages` → live at https://c64lib.github.io/gradle-retro-assembler-plugin/.
+3. Monitor: confirm the GitHub Pages build succeeded and the flows section renders correctly
+   live. No rollback risk beyond reverting the doc commit — documentation-only, no runtime impact.
+
+## 10. Revision History
+
+| Date | Updated By | Changes |
+|------|------------|---------|
+| 2026-07-18 | AI Agent | Initial draft created for issue #178 |
+| 2026-07-18 | AI Agent | Resolved Q1–Q4: full parameter tables for all steps, Kotlin+Groovy examples throughout, no diagrams. Propagated into requirements, Phase 2/3 steps, and risks. |
+| 2026-07-18 | AI Agent | Status → accepted (no unresolved questions). |
+
+---
+
+**Note**: This plan should be reviewed and approved before implementation begins.

--- a/plans/README.md
+++ b/plans/README.md
@@ -16,4 +16,4 @@ Plans are permanent artifacts — do not delete. Terminal plans (`implemented`, 
 | [PLAN-0009](PLAN-0009_document-crunchers-domain-in-kb.md) | 2026-07-17 | implemented | Document the `crunchers` domain in `doc/kb/domain.md` | #156 | [EXEC-0009](EXEC-0009_document-crunchers-domain-in-kb.md) |
 | [PLAN-0010](PLAN-0010_pipeline-dsl-spec64-support.md) | 2026-07-17 | implemented | Pipeline DSL - support for spec64 test framework | #130 | [EXEC-0010](EXEC-0010_pipeline-dsl-spec64-support.md) |
 | [PLAN-0011](PLAN-0011_flows-groovy-dsl-and-fat-jar-fix.md) | 2026-07-17 | implemented | Complete Groovy DSL Coverage for Flow Steps + Fix Stale Fat Jar Root Cause | #176 | [EXEC-0011](EXEC-0011_flows-groovy-dsl-and-fat-jar-fix.md) |
-| [PLAN-0012](PLAN-0012_flows-user-documentation.md) | 2026-07-18 | accepted | Extend User Documentation with Flows Capabilities | #178 | — |
+| [PLAN-0012](PLAN-0012_flows-user-documentation.md) | 2026-07-18 | implemented | Extend User Documentation with Flows Capabilities | #178 | [EXEC-0012](EXEC-0012_flows-user-documentation.md) |

--- a/plans/README.md
+++ b/plans/README.md
@@ -16,3 +16,4 @@ Plans are permanent artifacts — do not delete. Terminal plans (`implemented`, 
 | [PLAN-0009](PLAN-0009_document-crunchers-domain-in-kb.md) | 2026-07-17 | implemented | Document the `crunchers` domain in `doc/kb/domain.md` | #156 | [EXEC-0009](EXEC-0009_document-crunchers-domain-in-kb.md) |
 | [PLAN-0010](PLAN-0010_pipeline-dsl-spec64-support.md) | 2026-07-17 | implemented | Pipeline DSL - support for spec64 test framework | #130 | [EXEC-0010](EXEC-0010_pipeline-dsl-spec64-support.md) |
 | [PLAN-0011](PLAN-0011_flows-groovy-dsl-and-fat-jar-fix.md) | 2026-07-17 | implemented | Complete Groovy DSL Coverage for Flow Steps + Fix Stale Fat Jar Root Cause | #176 | [EXEC-0011](EXEC-0011_flows-groovy-dsl-and-fat-jar-fix.md) |
+| [PLAN-0012](PLAN-0012_flows-user-documentation.md) | 2026-07-18 | accepted | Extend User Documentation with Flows Capabilities | #178 | — |


### PR DESCRIPTION
Expands the "Pipeline DSL (Experimental)" section of the user manual (`doc/index.adoc`) into a complete, accurate reference for the flows subdomain.

## What changed
- **Full option/parameter tables** for every step type, verified property-by-property against the `*StepBuilder.kt` source classes — including the previously undocumented `dasmStep` and `exomizerStep`.
- **Kotlin and Groovy examples** for each step.
- **New subsections**: Parallel Execution, Change Detection & Incremental Builds, Path Helpers (`from`/`to`, `useFrom`/`useTo`), and Task Naming & Build Integration.
- **Refreshed Complete Example** — two flows with `dependsOn`, in both DSLs.
- Added a `CHANGES.adoc` entry; recorded PLAN-0012 / EXEC-0012 as implemented.

## Verification
`./gradlew :doc:asciidoctor` renders the manual cleanly (BUILD SUCCESSFUL); new sections confirmed present in the generated HTML.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
