### PR TITLE
Fix stale testStep results when derived spec artifacts already exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,13 @@ Step classes are immutable data classes representing individual processing steps
 - Remove verbose multi-paragraph documentation and code examples
 - Add inline comments only for non-obvious logic
 
+**64spec Test Results (`testStep`)**: The `.specOut` result file is written by the 64spec test
+program running *inside VICE*, not by the plugin, so `Run64SpecTestUseCase` cannot otherwise tell
+whether a run actually produced it. It therefore deletes any stale `.specOut` before invoking VICE
+and throws if `.specOut` is still missing afterward — a spec result always reflects the current run,
+or the build fails explicitly, even when derived `.prg`/`.vs`/`.specOut` already exist from a
+previous run.
+
 ### Example Step Implementation
 
 ```kotlin

--- a/flows/adapters/in/gradle/src/test/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/port/Spec64TestPortAdapterTest.kt
+++ b/flows/adapters/in/gradle/src/test/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/port/Spec64TestPortAdapterTest.kt
@@ -63,8 +63,12 @@ class Spec64TestPortAdapterTest :
         val runCalls = mutableListOf<ViceParameters>()
         val vicePort =
             object : RunTestOnVicePort {
+              var resultFile: File? = null
+              var resultContent: String = ""
+
               override fun run(parameters: ViceParameters) {
                 runCalls.add(parameters)
+                resultFile?.writeText(resultContent)
               }
             }
 
@@ -100,8 +104,10 @@ class Spec64TestPortAdapterTest :
           val tempDir = Files.createTempDirectory("spec-adapter").toFile()
           val spec = File(tempDir, "math.spec.asm")
           spec.writeText("sfspec: init_spec()")
-          // Run64SpecTestUseCase reads the .specOut result file produced by the run.
-          File(tempDir, "math.spec.specOut").writeText("Overall test report (3/3)")
+          // Run64SpecTestUseCase deletes any stale .specOut before running, so the fake VICE port
+          // must write it during run() to mirror the real 64spec-in-VICE behaviour.
+          vicePort.resultFile = File(tempDir, "math.spec.specOut")
+          vicePort.resultContent = "Overall test report (3/3)"
 
           val result = adapter.runSpec(spec)
 

--- a/plans/EXEC-0013_teststep-stale-spec-results.md
+++ b/plans/EXEC-0013_teststep-stale-spec-results.md
@@ -1,0 +1,36 @@
+# Execution Log: Fix stale pass/fail results in testStep when derived artifacts already exist
+
+**Exec ID**: EXEC-0013
+**Plan**: [PLAN-0013](PLAN-0013_teststep-stale-spec-results.md)
+**Issue**: #175
+**Started**: 2026-07-18
+**Last Updated**: 2026-07-18
+**State**: completed
+
+## 1. Execution Sessions
+
+### Session 1 — 2026-07-18
+
+- **Scope**: all (Phases 1-3)
+- **Mode**: per-phase
+- **Outcome**: completed
+
+| Step | Result | Verification | Notes |
+|------|--------|--------------|-------|
+| 1.1 | completed | `:flows:adapters:in:gradle:test` green (confirms fixed `Spec64TestPortAdapterTest`) | Delete of stale `.specOut` added at top of `Run64SpecTestUseCase.apply`, before the VICE call |
+| 1.2 | completed | same run as 1.1 | Existence guard added after VICE run, before `readBytes()`; throws `IllegalStateException` naming spec + expected path |
+| 2.1 | completed | `:testing:64spec:test` — 5/5 tests green (Run64SpecTestUseCaseTest.xml: tests=5 failures=0 errors=0) | New `src/test` bootstrapped in `testing/64spec`; covers fresh result, stale-not-rewritten (the #175 failure mode), stale-overwritten-with-different-content, `.prg`/`.vs` left intact, and missing-result exception message |
+| 3.1 | completed | e2e against `c64lib/common` (legacy `Run64Spec`/`test` task, not flows — see Deviation #2): baseline `test` run green (32/32) with plugin 1.8.1-SNAPSHOT published to mavenLocal; broke `math-add16.spec.asm`'s first assertion **without** deleting the resulting `.prg`/`.vs`/`.specOut`; re-run correctly reported `(31/32) FAILED` / spec `(18/19)`, matching clean-state behaviour instead of the pre-fix stale pass | Confirms the exact #175 repro is fixed on the legacy path, which shares `Run64SpecTestUseCase` with flows `testStep` |
+| 3.2 | completed | `spotlessCheck` green after `spotlessApply`; `:testing:64spec:test` and `:flows:adapters:in:gradle:test` both green | Added the 64spec test-results invariant to `CLAUDE.md` (Flows Subdomain Patterns → Common Patterns) and Kdoc to `Run64SpecTestUseCase` |
+
+## 2. Deviations from Plan
+
+| # | Step | Deviation | Reason | Impact |
+|---|------|-----------|--------|--------|
+| 1 | 1.1 | `/challenge` (mode A) run against the plan before execution surfaced that `flows/adapters/in/gradle/src/test/kotlin/.../port/Spec64TestPortAdapterTest.kt:99-115` pre-writes `math.spec.specOut` and calls `adapter.runSpec(spec)` with a fake `RunTestOnVicePort` that never writes the file — it currently relies on the pre-written `.specOut` surviving untouched. Once Step 1.1 deletes stale `.specOut` before invoking the VICE port, this existing test would start failing. | Not discovered during planning: the plan's "existing tests" search only checked `testing/64spec`, missing this adapter-level test in `flows/adapters/in/gradle`. | Fixing this test is treated as part of Step 1.1 (per user decision), not a plan rewrite — the fake `RunTestOnVicePort` will be updated to write `.specOut` when invoked, matching real VICE behavior. |
+| 2 | 3.1 | Plan's Step 3.1 assumed reproducing #175 via `flowVerificationStepSpecs` (a flows-based task) against `c64lib/common`. The local `common` checkout (branch `master`) uses the plain legacy DSL pinned to plugin `1.6.0`, with no `flows`/`testStep` block, and its `pluginManagement`/`mavenLocal()` override commented out in `settings.gradle`. Verified the **legacy `Run64Spec`/`test` task** path instead (per user decision) — it shares `Run64SpecTestUseCase` with flows `testStep`, so the fix is equally proven. Temporarily edited `common/settings.gradle` (uncommented `pluginManagement { repositories { mavenLocal() ... } }`) and `common/build.gradle` (plugin version `1.6.0` → `1.8.1-SNAPSHOT`) to point at the locally-published SNAPSHOT; reverted both via `git checkout --` immediately after verification, confirmed `common`'s working tree is clean. | `common`'s checked-out state doesn't match the flows-based setup implied by the plan/issue; avoided modifying a separate git repo's committed history. | No lasting change to `common`. Verification evidence lives only in this exec log's Session 1 table (Step 3.1) and this deviation row. |
+| 3 | 3.2 | New test file `Run64SpecTestUseCaseTest.kt` initially failed `spotlessKotlinCheck` (multi-line KDoc formatting, lambda block formatting). Fixed via `./gradlew :testing:64spec:spotlessApply`. | Standard ktfmt formatting rules; new file wasn't pre-formatted to match. | None — auto-fixed, re-verified green. |
+
+## 3. Follow-ups
+
+- None yet.

--- a/plans/PLAN-0013_teststep-stale-spec-results.md
+++ b/plans/PLAN-0013_teststep-stale-spec-results.md
@@ -1,0 +1,273 @@
+# Feature: Fix stale pass/fail results in testStep when derived artifacts already exist
+
+**Plan ID**: PLAN-0013
+**Issue**: #175
+**Status**: accepted
+**Created**: 2026-07-18
+**Last Updated**: 2026-07-18
+
+## 1. Feature Description
+
+### Overview
+The flows Pipeline DSL `testStep` can report a **stale pass** for a spec whose assertions now
+fail, whenever that spec's derived `.prg`/`.vs`/`.specOut` files already exist from a previous run.
+This plan makes the `.specOut` result always reflect the current run — either a fresh result or an
+explicit failure — by deleting the stale `.specOut` at the start of the run use case (before VICE)
+and refusing to parse a missing result file afterwards.
+
+### Requirements
+- A `testStep` re-run against pre-existing `.prg`/`.vs`/`.specOut` must reflect the newly assembled
+  spec, never a previous run's result.
+- If VICE does not (re)produce the `.specOut` for the current run, the step must fail loudly rather
+  than parse a leftover file.
+- The fix must also protect the legacy `Run64Spec` task path, not only flows, because both share the
+  same `Run64SpecTestUseCase`.
+- No change to the public DSL surface or spec-authoring conventions.
+
+### Success Criteria
+- With stale `.prg`/`.vs`/`.specOut` present, editing a spec to fail an assertion and re-running
+  `testStep` reports the failure and fails the build — matching clean-state behaviour.
+- A missing `.specOut` after a VICE run raises a clear error instead of a false green.
+- Regression coverage exists for both "stale artifacts present" and "result file missing".
+
+## 2. Root Cause Analysis
+
+The `.specOut` result file is **written by the 64spec test program running inside VICE**
+(`write_final_results_to_file` / `result_file_name` variables set in `KickAssembleSpecAdapter`),
+not by the plugin. The plugin therefore has no direct signal that VICE actually (re)wrote the file.
+
+`Run64SpecTestUseCase.apply` (`testing/64spec/.../Run64SpecTestUseCase.kt:32-39`) unconditionally
+runs VICE and then does `File(resultFile(testSource)).readBytes()`. If the current run does not
+overwrite the `.specOut` — e.g. the freshly assembled `.prg` fails to autostart, VICE exits early,
+or the write races the read — `readBytes()` returns the **previous run's** bytes, which
+`parseTestOutput` happily reports as a pass.
+
+The Gradle output-tracking layer is not the culprit: `TestTask.outputFiles` is declared
+`@get:OutputFiles` and wired in `FlowTasksGenerator.configureOutputFiles`, and VICE demonstrably
+runs on both invocations (the task is not `UP-TO-DATE`-skipped). The defect is purely that the
+use case reads back a file it never verified belongs to the current run.
+
+### Current State
+- `execute()` in `TestStep` loops specs: `assembleSpec(specFile)` then `runSpec(specFile)`
+  (`flows/.../steps/TestStep.kt:60-63`).
+- `assembleSpec` → `KickAssembleSpecUseCase` → `KickAssembleSpecAdapter.assemble` runs KickAssembler
+  via `project.javaexec`, emitting `.prg` and `.vs`.
+- `runSpec` → `Run64SpecTestUseCase.apply` runs VICE, then reads `resultFile(testSource)` (`.specOut`).
+- Nothing deletes prior `.prg`/`.vs`/`.specOut`, and nothing checks the `.specOut` is current.
+
+### Desired State
+- At the start of the run use case (after the caller has assembled the spec, before VICE), the stale
+  `.specOut` is deleted so a leftover result can never be read back.
+- After the VICE run, `Run64SpecTestUseCase` verifies the `.specOut` exists before parsing; if it is
+  absent, it throws a descriptive error.
+- Result: every reported pass/fail corresponds to the current run, or the build fails explicitly.
+
+### Gap Analysis
+- At the start of `Run64SpecTestUseCase.apply`, delete the spec's `.specOut` (tolerant of an
+  already-absent file) so no stale result survives into the run. `.prg`/`.vs` are **not** deleted
+  here — the caller just assembled them and VICE autostarts the `.prg`.
+- After the VICE run, add an existence guard on `.specOut` before `readBytes()`.
+- Add regression tests (the `testing/64spec` module currently has no `src/test`).
+
+## 3. Relevant Code Parts
+
+### Existing Components
+- **Run64SpecTestUseCase**: runs VICE and parses `.specOut`; the single fix site. Gains: (1) delete
+  the spec's stale `.specOut` at the start of `apply`, before the VICE run; (2) a `.specOut`
+  existence guard after the run, before `readBytes()`.
+  - Location: `testing/64spec/src/main/kotlin/.../usecase/Run64SpecTestUseCase.kt:31-39`
+  - Integration Point: shared by flows `testStep` and the legacy `Run64Spec` task, so the invariant
+    holds for both.
+- **functions.kt (64spec)**: `prgFile`, `resultFile`, `viceSymbolFile` derive artifact paths from the
+  spec source — the canonical set of files to delete/guard.
+  - Location: `testing/64spec/src/main/kotlin/.../usecase/functions.kt:29-33`
+- **KickAssembleSpecUseCase**: assembles a spec into `.prg`/`.vs`. **Unchanged** — re-assembly still
+  overwrites those files; deletion is handled run-side.
+  - Location: `compilers/kickass/src/main/kotlin/.../usecase/KickAssembleSpecUseCase.kt:30-41`
+- **Spec64TestPortAdapter**: bridges flows `TestPort` to the two use cases; unchanged in behaviour,
+  it simply benefits from the hardened run use case.
+  - Location: `flows/adapters/in/gradle/.../port/Spec64TestPortAdapter.kt:48-59`
+- **TestStep**: flows domain step running the assemble→run loop; unchanged.
+  - Location: `flows/src/main/kotlin/.../steps/TestStep.kt:52-75`
+- **TestStepTest**: existing flows-domain test using a `RecordingTestPort`; template for test style.
+  - Location: `flows/src/test/kotlin/.../steps/TestStepTest.kt`
+
+### Architecture Alignment
+- **Domain**: `testing/64spec` only — the run use case owns the whole `.specOut` lifecycle.
+- **Use Cases**: `Run64SpecTestUseCase.apply` gains, at its start, deletion of the spec's stale
+  `.specOut`, then (after the VICE run) a `.specOut` existence guard before parsing.
+  Keeps the single-`apply` shape. `KickAssembleSpecUseCase` is **not** modified.
+- **Ports**: no new port. Deletion uses `java.io.File` directly inside the use case, consistent with
+  the module already deriving paths via pure `functions.kt` helpers; no Gradle types leak in.
+- **Adapters**: none changed. `KickAssembleSpecAdapter` still owns the KickAssembler invocation and
+  overwrites `.prg`/`.vs` on re-assembly exactly as before.
+
+### Dependencies
+- None new. Deletion and existence checks use `java.io.File`, already used throughout these use cases.
+
+## 4. Questions and Clarifications
+
+### Self-Reflection Questions
+- **Q**: Why is the task not simply `UP-TO-DATE`-skipped, given outputs are declared?
+  - **A**: The edited `.spec.asm` is a declared input, so Gradle re-executes; VICE runs both times.
+    The bug is the use case reading a leftover `.specOut`, independent of Gradle up-to-date checks.
+- **Q**: Where should the fix live so it is reusable and unit-testable?
+  - **A**: In `Run64SpecTestUseCase` (the 64spec run use case). It is pure (only `java.io.File`),
+    unit-testable without Gradle, and shared by both flows and the legacy `Run64Spec` task — so the
+    invariant is enforced everywhere. Deletion and the existence guard land in the same use case.
+- **Q**: Should `.specOut` deletion live in the assemble use case or the run use case?
+  - **A**: The **run** use case, just before invoking VICE. This keeps the result file's entire
+    lifecycle — delete stale, run VICE (which writes it), guard existence, read — inside the single
+    use case that owns it, rather than splitting deletion (assemble) from the read (run).
+- **Q**: Which files are deleted before the run — all three derived artifacts?
+  - **A**: Only `.specOut`. In `TestStep.execute` the caller runs `assembleSpec(spec)` immediately
+    before `runSpec(spec)` (`TestStep.kt:60-63`), so `.prg`/`.vs` are freshly produced and VICE is
+    about to autostart the `.prg`; deleting them run-side would destroy the binary under test.
+    `.specOut` is the one file VICE writes *during* the run, so clearing only it is both sufficient
+    (it is the file read back) and safe.
+- **Q**: Does deleting artifacts before every run hurt incremental builds?
+  - **A**: Minimal impact. The task only executes when Gradle decides inputs changed; when it does
+    execute it must regenerate anyway. Deletion just guarantees the regeneration is observed.
+- **Q**: Does `KickAssembleSpecUseCase` need to change?
+  - **A**: No. With deletion moved run-side, the assemble use case is untouched; the whole fix is
+    contained in `testing/64spec`, and re-assembly still overwrites `.prg`/`.vs` as before.
+- **Q**: Does the `testing/64spec` module have existing tests?
+  - **A**: No — only `src/main`. The `rbt.domain` plugin provides Kotest; this plan adds `src/test`.
+
+### Unresolved Questions
+_None — all resolved._
+
+### Design Decisions
+- **Decision**: Fix approach for stale results.
+  - **Options**: (A) Delete derived artifacts before each run + guard result exists; (B) freshness
+    check via mtime only; (C) both delete and mtime-verify.
+  - **Recommendation**: **(A)** — chosen. Deletion is deterministic and immune to filesystem mtime
+    resolution issues; the post-run existence guard converts any silent VICE failure into a loud
+    build failure. Simpler and more robust than mtime comparison.
+- **Decision**: Fix location.
+  - **Options**: (A) in the 64spec/kickass use cases; (B) in the flows `Spec64TestPortAdapter`;
+    (C) in `TestStep.execute`.
+  - **Recommendation**: **(A)** — chosen, and further narrowed to **`Run64SpecTestUseCase` alone**:
+    both the delete-before-run and the existence guard live there. The run use case is pure and
+    unit-testable and the fix protects the legacy `Run64Spec` task path too. `KickAssembleSpecUseCase`
+    is not modified.
+- **Decision**: Which use case deletes the stale `.specOut`, and which files.
+  - **Options**: (A) assemble use case (all cleanup in one place); (B) run use case, just before VICE.
+  - **Recommendation**: **(B)** — chosen. Keeps the result file's full lifecycle (delete → run →
+    guard → read) inside the one use case that consumes it; the assemble use case stays untouched.
+    Only `.specOut` is deleted (not `.prg`/`.vs`): the caller assembles right before running, so the
+    binary must survive into the VICE autostart.
+
+## 5. Implementation Plan
+
+### Phase 1: Harden Run64SpecTestUseCase (core fix)
+**Goal**: Guarantee every `.specOut` read reflects the current run, or fails loudly.
+
+1. **Step 1.1**: Delete the stale `.specOut` at the start of the run use case, before VICE.
+   - Files: `testing/64spec/src/main/kotlin/.../usecase/Run64SpecTestUseCase.kt`
+   - Description: At the top of `apply`, before the `runTestOnViceUseCase.apply(...)` call, delete the
+     spec's `.specOut` if present, using the `resultFile` helper. Deletion must be tolerant of an
+     already-absent file. **Only `.specOut` is deleted run-side** — `.prg`/`.vs` were just written by
+     the caller's preceding `assembleSpec(spec)` (see `TestStep.execute` at `TestStep.kt:60-63`) and
+     VICE is about to autostart the `.prg`, so deleting them here would destroy the binary under test.
+     `.specOut` is the file VICE itself writes during the run, so clearing it first guarantees any
+     result read afterwards belongs to this run.
+   - Testing: unit test asserting `.specOut` is removed before the VICE port is invoked, and that
+     `.prg`/`.vs` are left intact.
+2. **Step 1.2**: Guard the result-file read after the run.
+   - Files: `testing/64spec/src/main/kotlin/.../usecase/Run64SpecTestUseCase.kt`
+   - Description: After the VICE run and before `readBytes()`, check `resultFile.exists()`; if it does
+     not, throw a descriptive exception naming the spec and the expected `.specOut` path, so a run
+     that failed to produce a result becomes a build failure instead of a stale/blank pass.
+   - Testing: unit test — missing `.specOut` → exception; present `.specOut` → parsed result.
+
+**Phase 1 Deliverable**: The core correctness fix, contained in one module and mergeable on its own —
+stale reads are eliminated and missing results fail the build, for both flows and the legacy task.
+
+### Phase 2: Regression tests
+**Goal**: Lock in the fixed behaviour with automated coverage.
+
+1. **Step 2.1**: Add `src/test` to the `testing/64spec` module for `Run64SpecTestUseCase`.
+   - Files: `testing/64spec/src/test/kotlin/.../usecase/Run64SpecTestUseCaseTest.kt`
+     (and `parseTestOutput`/`fromPetscii` coverage if convenient)
+   - Description: Fake `RunTestOnVicePort`. Cover the full lifecycle in one place:
+     (a) fake writes a fresh `.specOut` → correct `TestResult`;
+     (b) a **stale** `.specOut` pre-exists and the fake does NOT rewrite it → the pre-run deletion +
+     existence guard turn this into a thrown exception, never the stale pass (the exact #175 failure
+     mode);
+     (c) a fake that writes a *different* `.specOut` → the new content, not the old, is parsed;
+     (d) assert `.specOut` is deleted before the fake port runs, and that pre-existing `.prg`/`.vs`
+     are left intact (never deleted run-side).
+   - Testing: `./gradlew :testing:64spec:test`.
+
+**Phase 2 Deliverable**: Regression suite covering stale-artifact and missing-result scenarios,
+entirely within `testing/64spec`.
+
+### Phase 3: Verification and docs
+**Goal**: Confirm the real-world scenario and record the invariant.
+
+1. **Step 3.1**: E2E verification against a real spec project.
+   - Files: n/a (uses `c64lib/common` or the `e2e-test` harness)
+   - Description: Reproduce the issue's steps — run `flowVerificationStepSpecs`, break an assertion
+     **without** deleting artifacts, re-run, and confirm the build now fails with the corrected count.
+   - Testing: manual/e2e per the reproduction in issue #175.
+2. **Step 3.2**: Document the invariant.
+   - Files: `CLAUDE.md` (Flows Subdomain Patterns or a 64spec note), inline Kdoc on the run use case.
+   - Description: State that the stale `.specOut` is deleted before each run and a missing `.specOut`
+     afterwards is a hard failure, so spec results never go stale.
+   - Testing: doc review.
+
+**Phase 3 Deliverable**: E2E-confirmed fix plus documentation of the guarantee.
+
+## 6. Testing Strategy
+
+### Unit Tests
+- `Run64SpecTestUseCase` (bootstraps a new `src/test` in `testing/64spec`): deletes the stale
+  `.specOut` (and leaves `.prg`/`.vs` intact) before invoking the VICE port; missing `.specOut` after
+  the run throws; present `.specOut` parses; a fake that rewrites `.specOut` yields the new content,
+  not stale.
+
+### Integration Tests
+- Optional flows-level test via `Spec64TestPortAdapter` with fakes, asserting the hardened run use
+  case composes correctly through the adapter. The existing `TestStepTest` `RecordingTestPort` pattern
+  is the model.
+
+### Manual Testing
+- The issue #175 reproduction against `c64lib/common`: pre-existing artifacts + broken assertion +
+  re-run must fail with the corrected `(n/m)` count, matching clean-state behaviour.
+
+## 7. Risks and Mitigation
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Run-side deletion accidentally removes `.prg`/`.vs`, destroying the binary VICE autostarts | High | Low | Design deletes **only `.specOut`** run-side; `.prg`/`.vs` are produced by the caller's preceding `assembleSpec` and left untouched. Unit-test asserts `.prg`/`.vs` survive. |
+| Path derivation for the deleted `.specOut` diverges from what VICE writes (wrong file deleted/kept) | Medium | Low | Reuse the same `resultFile` helper VICE's result path is derived from; unit-test the deleted set. |
+| Legacy `Run64Spec` task behaviour changes unexpectedly | Low | Low | Change is additive (delete-then-run, guard-before-read); covered by unit tests; e2e exercises the path indirectly. |
+| Deletion adds slight rebuild cost | Low | High | Only occurs when the task actually executes (inputs changed), which already regenerates artifacts. |
+
+## 8. Documentation Updates
+
+- [ ] Update CLAUDE.md (flows/64spec) with the "stale `.specOut` deleted before each run; missing
+      `.specOut` is a hard failure" invariant.
+- [ ] Add inline Kdoc to `Run64SpecTestUseCase.apply` (deletes stale `.specOut` before the run, guards
+      result-file existence after).
+- [ ] No README/arc42 architecture change (no new port/domain/wiring).
+
+## 9. Rollout Plan
+
+1. Ship Phase 1 (+ Phase 2 tests) on a feature branch, PR into `develop`.
+2. Verify via the issue #175 e2e reproduction before merge.
+3. Rollback strategy: revert is safe and isolated — the change only affects `Run64SpecTestUseCase`;
+   no schema, DSL, or task-graph changes to unwind.
+
+## 10. Revision History
+
+| Date | Updated By | Changes |
+|------|------------|---------|
+| 2026-07-18 | AI Agent | Initial draft. |
+| 2026-07-18 | AI Agent | Resolved fix-location question: whole fix in `Run64SpecTestUseCase` (run-side), `KickAssembleSpecUseCase` untouched. Narrowed run-side deletion to **`.specOut` only** — `.prg`/`.vs` must survive into VICE autostart since the caller assembles immediately before running. Propagated through overview, gap analysis, architecture, phases, tests, and risks. |
+| 2026-07-18 | AI Agent | Status → accepted (all Unresolved Questions resolved). |
+
+---
+
+**Note**: This plan should be reviewed and approved before implementation begins.

--- a/plans/PLAN-0013_teststep-stale-spec-results.md
+++ b/plans/PLAN-0013_teststep-stale-spec-results.md
@@ -2,7 +2,7 @@
 
 **Plan ID**: PLAN-0013
 **Issue**: #175
-**Status**: accepted
+**Status**: implemented
 **Created**: 2026-07-18
 **Last Updated**: 2026-07-18
 
@@ -160,10 +160,11 @@ _None — all resolved._
 
 ## 5. Implementation Plan
 
-### Phase 1: Harden Run64SpecTestUseCase (core fix)
+### Phase 1: Harden Run64SpecTestUseCase (core fix) — ✅ completed
+
 **Goal**: Guarantee every `.specOut` read reflects the current run, or fails loudly.
 
-1. **Step 1.1**: Delete the stale `.specOut` at the start of the run use case, before VICE.
+1. - [x] **Step 1.1**: Delete the stale `.specOut` at the start of the run use case, before VICE.
    - Files: `testing/64spec/src/main/kotlin/.../usecase/Run64SpecTestUseCase.kt`
    - Description: At the top of `apply`, before the `runTestOnViceUseCase.apply(...)` call, delete the
      spec's `.specOut` if present, using the `resultFile` helper. Deletion must be tolerant of an
@@ -174,7 +175,7 @@ _None — all resolved._
      result read afterwards belongs to this run.
    - Testing: unit test asserting `.specOut` is removed before the VICE port is invoked, and that
      `.prg`/`.vs` are left intact.
-2. **Step 1.2**: Guard the result-file read after the run.
+2. - [x] **Step 1.2**: Guard the result-file read after the run.
    - Files: `testing/64spec/src/main/kotlin/.../usecase/Run64SpecTestUseCase.kt`
    - Description: After the VICE run and before `readBytes()`, check `resultFile.exists()`; if it does
      not, throw a descriptive exception naming the spec and the expected `.specOut` path, so a run
@@ -184,10 +185,11 @@ _None — all resolved._
 **Phase 1 Deliverable**: The core correctness fix, contained in one module and mergeable on its own —
 stale reads are eliminated and missing results fail the build, for both flows and the legacy task.
 
-### Phase 2: Regression tests
+### Phase 2: Regression tests — ✅ completed
+
 **Goal**: Lock in the fixed behaviour with automated coverage.
 
-1. **Step 2.1**: Add `src/test` to the `testing/64spec` module for `Run64SpecTestUseCase`.
+1. - [x] **Step 2.1**: Add `src/test` to the `testing/64spec` module for `Run64SpecTestUseCase`.
    - Files: `testing/64spec/src/test/kotlin/.../usecase/Run64SpecTestUseCaseTest.kt`
      (and `parseTestOutput`/`fromPetscii` coverage if convenient)
    - Description: Fake `RunTestOnVicePort`. Cover the full lifecycle in one place:
@@ -203,15 +205,16 @@ stale reads are eliminated and missing results fail the build, for both flows an
 **Phase 2 Deliverable**: Regression suite covering stale-artifact and missing-result scenarios,
 entirely within `testing/64spec`.
 
-### Phase 3: Verification and docs
+### Phase 3: Verification and docs — ✅ completed
+
 **Goal**: Confirm the real-world scenario and record the invariant.
 
-1. **Step 3.1**: E2E verification against a real spec project.
+1. - [x] **Step 3.1**: E2E verification against a real spec project.
    - Files: n/a (uses `c64lib/common` or the `e2e-test` harness)
    - Description: Reproduce the issue's steps — run `flowVerificationStepSpecs`, break an assertion
      **without** deleting artifacts, re-run, and confirm the build now fails with the corrected count.
    - Testing: manual/e2e per the reproduction in issue #175.
-2. **Step 3.2**: Document the invariant.
+2. - [x] **Step 3.2**: Document the invariant.
    - Files: `CLAUDE.md` (Flows Subdomain Patterns or a 64spec note), inline Kdoc on the run use case.
    - Description: State that the stale `.specOut` is deleted before each run and a missing `.specOut`
      afterwards is a hard failure, so spec results never go stale.
@@ -247,11 +250,11 @@ entirely within `testing/64spec`.
 
 ## 8. Documentation Updates
 
-- [ ] Update CLAUDE.md (flows/64spec) with the "stale `.specOut` deleted before each run; missing
+- [x] Update CLAUDE.md (flows/64spec) with the "stale `.specOut` deleted before each run; missing
       `.specOut` is a hard failure" invariant.
-- [ ] Add inline Kdoc to `Run64SpecTestUseCase.apply` (deletes stale `.specOut` before the run, guards
+- [x] Add inline Kdoc to `Run64SpecTestUseCase.apply` (deletes stale `.specOut` before the run, guards
       result-file existence after).
-- [ ] No README/arc42 architecture change (no new port/domain/wiring).
+- [x] No README/arc42 architecture change (no new port/domain/wiring) — confirmed, none needed.
 
 ## 9. Rollout Plan
 
@@ -267,6 +270,7 @@ entirely within `testing/64spec`.
 | 2026-07-18 | AI Agent | Initial draft. |
 | 2026-07-18 | AI Agent | Resolved fix-location question: whole fix in `Run64SpecTestUseCase` (run-side), `KickAssembleSpecUseCase` untouched. Narrowed run-side deletion to **`.specOut` only** — `.prg`/`.vs` must survive into VICE autostart since the caller assembles immediately before running. Propagated through overview, gap analysis, architecture, phases, tests, and risks. |
 | 2026-07-18 | AI Agent | Status → accepted (all Unresolved Questions resolved). |
+| 2026-07-18 | AI Agent | Status → implemented. All 5 steps executed and verified (see [EXEC-0013](EXEC-0013_teststep-stale-spec-results.md)): `/challenge` review before execution caught that `Spec64TestPortAdapterTest.kt` would break, fixed inline; e2e-verified the exact #175 repro against `c64lib/common`'s legacy `Run64Spec` task (flows `testStep` shares the same use case); CLAUDE.md and Kdoc updated. |
 
 ---
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -17,4 +17,4 @@ Plans are permanent artifacts — do not delete. Terminal plans (`implemented`, 
 | [PLAN-0010](PLAN-0010_pipeline-dsl-spec64-support.md) | 2026-07-17 | implemented | Pipeline DSL - support for spec64 test framework | #130 | [EXEC-0010](EXEC-0010_pipeline-dsl-spec64-support.md) |
 | [PLAN-0011](PLAN-0011_flows-groovy-dsl-and-fat-jar-fix.md) | 2026-07-17 | implemented | Complete Groovy DSL Coverage for Flow Steps + Fix Stale Fat Jar Root Cause | #176 | [EXEC-0011](EXEC-0011_flows-groovy-dsl-and-fat-jar-fix.md) |
 | [PLAN-0012](PLAN-0012_flows-user-documentation.md) | 2026-07-18 | implemented | Extend User Documentation with Flows Capabilities | #178 | [EXEC-0012](EXEC-0012_flows-user-documentation.md) |
-| [PLAN-0013](PLAN-0013_teststep-stale-spec-results.md) | 2026-07-18 | accepted | Fix stale pass/fail results in testStep when derived artifacts already exist | #175 | — |
+| [PLAN-0013](PLAN-0013_teststep-stale-spec-results.md) | 2026-07-18 | implemented | Fix stale pass/fail results in testStep when derived artifacts already exist | #175 | [EXEC-0013](EXEC-0013_teststep-stale-spec-results.md) |

--- a/plans/README.md
+++ b/plans/README.md
@@ -17,3 +17,4 @@ Plans are permanent artifacts — do not delete. Terminal plans (`implemented`, 
 | [PLAN-0010](PLAN-0010_pipeline-dsl-spec64-support.md) | 2026-07-17 | implemented | Pipeline DSL - support for spec64 test framework | #130 | [EXEC-0010](EXEC-0010_pipeline-dsl-spec64-support.md) |
 | [PLAN-0011](PLAN-0011_flows-groovy-dsl-and-fat-jar-fix.md) | 2026-07-17 | implemented | Complete Groovy DSL Coverage for Flow Steps + Fix Stale Fat Jar Root Cause | #176 | [EXEC-0011](EXEC-0011_flows-groovy-dsl-and-fat-jar-fix.md) |
 | [PLAN-0012](PLAN-0012_flows-user-documentation.md) | 2026-07-18 | implemented | Extend User Documentation with Flows Capabilities | #178 | [EXEC-0012](EXEC-0012_flows-user-documentation.md) |
+| [PLAN-0013](PLAN-0013_teststep-stale-spec-results.md) | 2026-07-18 | accepted | Fix stale pass/fail results in testStep when derived artifacts already exist | #175 | — |

--- a/testing/64spec/src/main/kotlin/com/github/c64lib/rbt/testing/a64spec/usecase/Run64SpecTestUseCase.kt
+++ b/testing/64spec/src/main/kotlin/com/github/c64lib/rbt/testing/a64spec/usecase/Run64SpecTestUseCase.kt
@@ -28,13 +28,26 @@ import com.github.c64lib.rbt.emulators.vice.usecase.RunTestOnViceCommand
 import com.github.c64lib.rbt.emulators.vice.usecase.RunTestOnViceUseCase
 import java.io.File
 
+/**
+ * Runs a 64spec spec on VICE and parses its `.specOut` result.
+ *
+ * The `.specOut` file is written by the 64spec test program running *inside* VICE, so a stale file
+ * from a previous run is deleted before VICE starts, and its absence afterward is a hard failure —
+ * a result is never read unless this run produced it.
+ */
 class Run64SpecTestUseCase(private val runTestOnViceUseCase: RunTestOnViceUseCase) {
   fun apply(testSource: File): TestResult {
+    val resultFile = File(resultFile(testSource))
+    resultFile.delete()
     runTestOnViceUseCase.apply(
         RunTestOnViceCommand(
             autostart = File(prgFile(testSource.absoluteFile)),
             monCommands = File(viceSymbolFile(testSource))))
-    val resultFile = File(resultFile(testSource))
+    if (!resultFile.exists()) {
+      throw IllegalStateException(
+          "Spec '${testSource.name}' did not produce a result file: expected " +
+              "'${resultFile.path}' after running VICE")
+    }
     return parseTestOutput(fromPetscii(resultFile.readBytes()))
   }
 

--- a/testing/64spec/src/test/kotlin/com/github/c64lib/rbt/testing/a64spec/usecase/Run64SpecTestUseCaseTest.kt
+++ b/testing/64spec/src/test/kotlin/com/github/c64lib/rbt/testing/a64spec/usecase/Run64SpecTestUseCaseTest.kt
@@ -1,0 +1,146 @@
+/*
+MIT License
+
+Copyright (c) 2018-2025 c64lib: The Ultimate Commodore 64 Library
+Copyright (c) 2018-2025 Maciej Małecki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package com.github.c64lib.rbt.testing.a64spec.usecase
+
+import com.github.c64lib.rbt.emulators.vice.usecase.RunTestOnViceUseCase
+import com.github.c64lib.rbt.emulators.vice.usecase.port.RunTestOnVicePort
+import com.github.c64lib.rbt.emulators.vice.usecase.port.ViceParameters
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.file.shouldExist
+import io.kotest.matchers.file.shouldNotExist
+import io.kotest.matchers.shouldBe
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Fake VICE port whose [run] optionally (re)writes the `.specOut` result file, like real VICE does.
+ */
+private class FakeVicePort(private val onRun: (ViceParameters) -> Unit = {}) : RunTestOnVicePort {
+  var runCount = 0
+
+  override fun run(parameters: ViceParameters) {
+    runCount++
+    onRun(parameters)
+  }
+}
+
+class Run64SpecTestUseCaseTest :
+    BehaviorSpec({
+      fun tempSpec(): File {
+        val tempDir = Files.createTempDirectory("run64spec-test").toFile()
+        val spec = File(tempDir, "math.spec.asm")
+        spec.writeText("sfspec: init_spec()")
+        return spec
+      }
+
+      given("a spec whose VICE run writes a fresh .specOut") {
+        val spec = tempSpec()
+        val specOut = File(spec.parentFile, "math.spec.specOut")
+        val vicePort = FakeVicePort { specOut.writeText("Overall test report (3/3)") }
+        val useCase = Run64SpecTestUseCase(RunTestOnViceUseCase(vicePort))
+
+        `when`("running the spec") {
+          val result = useCase.apply(spec)
+
+          then("it parses the fresh result") {
+            result.successCount shouldBe 3
+            result.totalCount shouldBe 3
+            vicePort.runCount shouldBe 1
+          }
+        }
+      }
+
+      given("a stale .specOut from a previous run that VICE does not rewrite") {
+        val spec = tempSpec()
+        val specOut = File(spec.parentFile, "math.spec.specOut")
+        specOut.writeText("Overall test report (3/3)")
+        val vicePort = FakeVicePort() // does not write .specOut
+        val useCase = Run64SpecTestUseCase(RunTestOnViceUseCase(vicePort))
+
+        `when`("running the spec") {
+          then("the stale result is deleted before the run and never read back as a pass") {
+            shouldThrow<IllegalStateException> { useCase.apply(spec) }
+            vicePort.runCount shouldBe 1
+            specOut.shouldNotExist()
+          }
+        }
+      }
+
+      given("a stale .specOut that VICE overwrites with a different result") {
+        val spec = tempSpec()
+        val specOut = File(spec.parentFile, "math.spec.specOut")
+        specOut.writeText("Overall test report (3/3)")
+        val vicePort = FakeVicePort { specOut.writeText("Overall test report (1/3)") }
+        val useCase = Run64SpecTestUseCase(RunTestOnViceUseCase(vicePort))
+
+        `when`("running the spec") {
+          val result = useCase.apply(spec)
+
+          then("the new content is parsed, not the stale one") {
+            result.successCount shouldBe 1
+            result.totalCount shouldBe 3
+          }
+        }
+      }
+
+      given("a spec with pre-existing .prg and .vs, and no .specOut") {
+        val spec = tempSpec()
+        val prg = File(spec.parentFile, "math.spec.prg")
+        val vs = File(spec.parentFile, "math.spec.vs")
+        prg.writeText("prg-bytes")
+        vs.writeText("vs-bytes")
+        val vicePort = FakeVicePort {
+          File(spec.parentFile, "math.spec.specOut").writeText("(2/2)")
+        }
+        val useCase = Run64SpecTestUseCase(RunTestOnViceUseCase(vicePort))
+
+        `when`("running the spec") {
+          useCase.apply(spec)
+
+          then(".prg and .vs are left untouched") {
+            prg.shouldExist()
+            vs.shouldExist()
+            prg.readText() shouldBe "prg-bytes"
+            vs.readText() shouldBe "vs-bytes"
+          }
+        }
+      }
+
+      given("a VICE run that never produces a .specOut") {
+        val spec = tempSpec()
+        val vicePort = FakeVicePort() // never writes .specOut
+        val useCase = Run64SpecTestUseCase(RunTestOnViceUseCase(vicePort))
+
+        `when`("running the spec") {
+          then("a descriptive exception is thrown instead of a missing-file crash") {
+            val exception = shouldThrow<IllegalStateException> { useCase.apply(spec) }
+            exception.message shouldBe
+                "Spec 'math.spec.asm' did not produce a result file: expected " +
+                    "'${resultFile(spec)}' after running VICE"
+          }
+        }
+      }
+    })


### PR DESCRIPTION
## Summary

`Run64SpecTestUseCase` could report a stale **pass** for a 64spec spec whose assertions now fail, if that spec's derived `.prg`/`.vs`/`.specOut` files already existed from a previous run. The `.specOut` result file is written by the 64spec test program running *inside VICE*, so the plugin had no signal that the current run actually produced it — a run that failed to (re)write `.specOut` would silently read back the previous run's result as a pass.

- `Run64SpecTestUseCase.apply` now deletes any stale `.specOut` before invoking VICE, and throws if the result file is still missing afterward. Only `.specOut` is deleted — `.prg`/`.vs` are left untouched since the caller (`TestStep.execute` / the legacy `Run64Spec` task) assembles them immediately before running.
- Fixed the pre-existing `Spec64TestPortAdapterTest` so its fake VICE port writes `.specOut`, matching real VICE behavior now that the use case clears it first.
- Added `Run64SpecTestUseCaseTest` (new `src/test` in `testing/64spec`) covering: fresh result, stale-not-rewritten (the exact #175 failure mode), stale-overwritten-with-different-content, `.prg`/`.vs` left intact, and the missing-result exception.
- Documented the invariant in `CLAUDE.md` and Kdoc.
- Verified end-to-end against `c64lib/common`'s legacy `Run64Spec` task (shares `Run64SpecTestUseCase` with flows `testStep`): corrupting an assertion without deleting prior derived artifacts now correctly fails the build (`31/32`) instead of reporting a stale pass.

See [PLAN-0013](plans/PLAN-0013_teststep-stale-spec-results.md) and [EXEC-0013](plans/EXEC-0013_teststep-stale-spec-results.md) for full design rationale and execution record.

Closes #175

## Test plan
- [x] `:testing:64spec:test` — new regression suite green (5/5)
- [x] `:flows:adapters:in:gradle:test` — green, including the updated adapter test
- [x] `spotlessCheck` clean
- [x] e2e verification against `c64lib/common`'s legacy `Run64Spec` task

🤖 Generated with [Claude Code](https://claude.com/claude-code)