### PR TITLE
Fix empty-path flow artifact collision blocking all Gradle tasks (#181)

### DIFF
--- a/flows/adapters/in/gradle/src/main/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/FlowDsl.kt
+++ b/flows/adapters/in/gradle/src/main/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/FlowDsl.kt
@@ -273,12 +273,18 @@ class FlowBuilder(private val name: String) {
   /** Adds a built step and registers its input/output artifacts for dependency tracking. */
   private fun registerStep(stepName: String, step: FlowStep) {
     steps.add(step)
-    step.inputs.forEach { input ->
-      inputs.add(FlowArtifact("${stepName}_input_${inputs.size}", input))
-    }
-    step.outputs.forEach { output ->
-      outputs.add(FlowArtifact("${stepName}_output_${outputs.size}", output))
-    }
+    // Skip empty paths: a filter-only step output (e.g. Charpad `tiles { interleaver { ... } }`)
+    // carries an empty primary path whose real files come from the filter sub-outputs. Registering
+    // it as an artifact would create a `''` producer path that collides across flows during
+    // validation (issue #181). Mirrors the empty-path filtering in FlowTasksGenerator.
+    step.inputs
+        .filter { it.isNotEmpty() }
+        .forEach { input -> inputs.add(FlowArtifact("${stepName}_input_${inputs.size}", input)) }
+    step.outputs
+        .filter { it.isNotEmpty() }
+        .forEach { output ->
+          outputs.add(FlowArtifact("${stepName}_output_${outputs.size}", output))
+        }
   }
 
   internal fun build(): Flow =

--- a/flows/adapters/in/gradle/src/test/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/FilterOnlyEmptyPathCollisionTest.kt
+++ b/flows/adapters/in/gradle/src/test/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/FilterOnlyEmptyPathCollisionTest.kt
@@ -1,0 +1,141 @@
+/*
+MIT License
+
+Copyright (c) 2018-2025 c64lib: The Ultimate Commodore 64 Library
+Copyright (c) 2018-2025 Maciej Małecki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package com.github.c64lib.rbt.flows.adapters.`in`.gradle
+
+import com.github.c64lib.rbt.flows.adapters.`in`.gradle.dsl.CharpadStepBuilder
+import com.github.c64lib.rbt.flows.domain.FlowService
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression coverage for issue #181: a filter-only Charpad output block (an
+ * `interleaver`/`nybbler` filter with no primary `output`) carries an empty primary path. Before
+ * the fix this empty path was registered as a `''` produced [FlowArtifact], and two flows each
+ * declaring such a block collided during flow validation ("Artifact path '' is produced by multiple
+ * flows"), aborting every Gradle task at configuration time.
+ *
+ * These tests drive the real DSL → `build()` → [FlowService.validateFlows] path (where the empty
+ * path is actually born), not hand-built `Flow.produces`, so they faithfully reproduce the bug.
+ */
+class FilterOnlyEmptyPathCollisionTest :
+    BehaviorSpec({
+      Given("a Charpad step with a filter-only tiles block (no primary output)") {
+        val step =
+            CharpadStepBuilder("font")
+                .apply {
+                  from("intro.ctm")
+                  tiles {
+                    interleaver { outputs = listOf("intro.tiles.bin", "intro-odd.tiles.bin") }
+                  }
+                }
+                .build()
+
+        When("computing the step outputs") {
+          Then("the real interleaver sub-outputs are present") {
+            step.outputs shouldContainAll listOf("intro.tiles.bin", "intro-odd.tiles.bin")
+          }
+
+          Then("no empty output path leaks in") { step.outputs shouldNotContain "" }
+        }
+
+        And("the block still counts as producing outputs") {
+          step.charpadOutputs.hasOutputs() shouldBe true
+        }
+      }
+
+      Given("a Charpad step with an empty meta block") {
+        // meta {} is added unconditionally by the builder, so an unset output stays "".
+        val step =
+            CharpadStepBuilder("meta-empty")
+                .apply {
+                  from("intro.ctm")
+                  charset { output = "charset.chr" }
+                  meta {}
+                }
+                .build()
+
+        When("computing the step outputs") {
+          Then("the real charset output survives and no empty path leaks in") {
+            step.outputs shouldContain "charset.chr"
+            step.outputs shouldNotContain ""
+          }
+        }
+      }
+
+      Given("two flows that each contain a filter-only Charpad block") {
+        // Reproduces tony's intro/game topology from issue #181, driven through FlowDslBuilder —
+        // the same entry point the Gradle plugin uses (it also marks unproduced consumed inputs as
+        // source files, so raw .ctm inputs are not reported as missing producers).
+        val flows =
+            FlowDslBuilder()
+                .apply {
+                  flow("intro") {
+                    charpadStep("font") {
+                      from("intro.ctm")
+                      tiles {
+                        interleaver { outputs = listOf("intro.tiles.bin", "intro-odd.tiles.bin") }
+                      }
+                    }
+                  }
+                  flow("game") {
+                    charpadStep("tiles") {
+                      from("game.ctm")
+                      tiles {
+                        interleaver { outputs = listOf("game.tiles.bin", "game-odd.tiles.bin") }
+                      }
+                    }
+                  }
+                }
+                .build()
+
+        val introFlow = flows.first { it.name == "intro" }
+        val gameFlow = flows.first { it.name == "game" }
+
+        When("validating both flows together") {
+          val result = FlowService().validateFlows(flows)
+
+          Then("validation does not fail on an empty artifact path") {
+            // Would throw FlowValidationException("Artifact path '' is produced by multiple flows")
+            // before the fix; reaching here at all means the empty-path collision is gone.
+            result.hasErrors shouldBe false
+          }
+
+          Then("neither flow registers an empty produced artifact") {
+            introFlow.produces.map { it.path } shouldNotContain ""
+            gameFlow.produces.map { it.path } shouldNotContain ""
+          }
+
+          Then("the real filter sub-outputs are still registered as produced artifacts") {
+            introFlow.produces.map { it.path } shouldContainAll
+                listOf("intro.tiles.bin", "intro-odd.tiles.bin")
+            gameFlow.produces.map { it.path } shouldContainAll
+                listOf("game.tiles.bin", "game-odd.tiles.bin")
+          }
+        }
+      }
+    })

--- a/flows/src/main/kotlin/com/github/c64lib/rbt/flows/domain/config/CharpadOutputs.kt
+++ b/flows/src/main/kotlin/com/github/c64lib/rbt/flows/domain/config/CharpadOutputs.kt
@@ -180,18 +180,23 @@ data class CharpadOutputs(
 ) {
   /** Returns all output file paths for dependency tracking. */
   fun getAllOutputPaths(): List<String> {
+    // Filter-only output blocks (e.g. `tiles { interleaver { ... } }`) and empty `meta {}` carry an
+    // empty primary `output`; their real files come from the filter sub-outputs below. Drop the
+    // blanks so they never register as `''` artifacts (mirrors FlowTasksGenerator.kt empty-path
+    // filtering) — see issue #181.
     val primaryOutputs =
-        charsets.map { it.output } +
-            charAttributes.map { it.output } +
-            charColours.map { it.output } +
-            charMaterials.map { it.output } +
-            charScreenColours.map { it.output } +
-            tiles.map { it.output } +
-            tileTags.map { it.output } +
-            tileColours.map { it.output } +
-            tileScreenColours.map { it.output } +
-            maps.map { it.output } +
-            metadata.map { it.output }
+        (charsets.map { it.output } +
+                charAttributes.map { it.output } +
+                charColours.map { it.output } +
+                charMaterials.map { it.output } +
+                charScreenColours.map { it.output } +
+                tiles.map { it.output } +
+                tileTags.map { it.output } +
+                tileColours.map { it.output } +
+                tileScreenColours.map { it.output } +
+                maps.map { it.output } +
+                metadata.map { it.output })
+            .filter { it.isNotEmpty() }
 
     val rangeFilterOutputs =
         (charsets +

--- a/plans/EXEC-0016_flows-empty-artifact-path-collision.md
+++ b/plans/EXEC-0016_flows-empty-artifact-path-collision.md
@@ -1,0 +1,36 @@
+# Execution Log: Fix empty-path flow artifact collision blocking all Gradle tasks
+
+**Exec ID**: EXEC-0016
+**Plan**: [PLAN-0016](PLAN-0016_flows-empty-artifact-path-collision.md)
+**Issue**: #181
+**Started**: 2026-07-19
+**Last Updated**: 2026-07-19
+**State**: completed
+
+## 1. Execution Sessions
+
+### Session 1 — 2026-07-19
+
+- **Scope**: all (Steps 1.1, 1.2, 1.3, 2.1)
+- **Mode**: autonomous
+- **Outcome**: completed — all 4 steps done and verified
+
+| Step | Result | Verification | Notes |
+|------|--------|--------------|-------|
+| 1.1 | completed | `:flows:test` green; unit assertions pass | Filtered empty `primaryOutputs` sub-list in `CharpadOutputs.getAllOutputPaths()` with `isNotEmpty()`. |
+| 1.2 | completed | `:flows:adapters:in:gradle:test` green | Filtered empty in/out paths in `FlowDsl.registerStep()` with `isNotEmpty()`. |
+| 1.3 | completed | Fails on HEAD (lines 61/83) without fix; green with fix | New `FilterOnlyEmptyPathCollisionTest` drives DSL→`FlowDslBuilder.build()`→`FlowService.validateFlows`; asserts no empty artifact + sub-outputs survive. |
+| 2.1 | completed | tony `./gradlew tasks` + `flows` BUILD SUCCESSFUL; no "produced by multiple flows" error; 68 flow steps ran; artifacts present & non-empty | Fix confirmed against the originating harness (plugin published to mavenLocal 1.8.1-SNAPSHOT). |
+
+## 2. Deviations from Plan
+
+| # | Step | Deviation | Reason | Impact |
+|---|------|-----------|--------|--------|
+| 1 | 1.3 | Regression test drives `FlowDslBuilder` (`flow("intro"){...}`) instead of `FlowBuilder(...).build()` directly. | `FlowBuilder.build()` alone does not mark unproduced consumed inputs as source files — that happens in `FlowDslBuilder.build()` (FlowDsl.kt:66-76). Using `FlowBuilder` directly made the raw `.ctm` inputs trip a spurious `MissingArtifactProducer` ERROR unrelated to #181. | Test now exercises the true plugin entry point (more faithful reproduction); no production change. |
+
+## 3. Follow-ups
+
+- tony's `flows` run emits pre-existing, unrelated warnings — a `loader` orphaned-flow warning
+  ("produces artifacts that are never consumed: build-loader_output_0") and Gradle
+  implicit-task-dependency optimization warnings around charpad outputs. Neither is the #181 bug
+  and neither fails the build; candidate for a separate cleanup issue if desired.

--- a/plans/PLAN-0016_flows-empty-artifact-path-collision.md
+++ b/plans/PLAN-0016_flows-empty-artifact-path-collision.md
@@ -2,7 +2,7 @@
 
 **Plan ID**: PLAN-0016
 **Issue**: #181
-**Status**: accepted
+**Status**: implemented
 **Challenge**: revised 2026-07-19
 **Created**: 2026-07-19
 **Last Updated**: 2026-07-19
@@ -195,7 +195,7 @@ empty-path guard sits at the registration choke point so no step type can reintr
 **Goal**: Empty output paths never enter `CharpadStep.outputs` or the flow artifact registry;
 regression tests lock the behaviour in.
 
-1. **Step 1.1**: Filter empty primary outputs in `CharpadOutputs.getAllOutputPaths()`.
+1. **Step 1.1** — [x] done: Filter empty primary outputs in `CharpadOutputs.getAllOutputPaths()`.
    - Files: `flows/src/main/kotlin/com/github/c64lib/rbt/flows/domain/config/CharpadOutputs.kt`
    - Description: Apply `.filter { it.isNotEmpty() }` to the **`primaryOutputs` sub-list only**
      (CharpadOutputs.kt:183–194), leaving `rangeFilterOutputs`/`mapFilterOutputs` untouched. Use
@@ -209,7 +209,7 @@ regression tests lock the behaviour in.
      filter sub-output paths, no `""`; **assert the real filter sub-outputs are still present**; and
      `hasOutputs()` stays true. Add a case for an empty `meta {}` output (unguarded builder path).
 
-2. **Step 1.2**: Filter empty paths at the artifact-registration choke point in `FlowDsl.registerStep()`.
+2. **Step 1.2** — [x] done: Filter empty paths at the artifact-registration choke point in `FlowDsl.registerStep()`.
    - Files: `flows/adapters/in/gradle/src/main/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/FlowDsl.kt`
    - Description: In `registerStep`, skip blank entries when building input/output `FlowArtifact`s
      (guard the `step.inputs`/`step.outputs` iterations at lines 276–281 with `isNotEmpty()`).
@@ -217,7 +217,8 @@ regression tests lock the behaviour in.
    - Testing: Unit test — a step whose `outputs` (and `inputs`) contain `""` registers no empty-path
      artifact.
 
-3. **Step 1.3**: Integration regression test for the two-flow collision — **through the real DSL path**.
+3. **Step 1.3** — [x] done: Integration regression test for the two-flow collision — **through the real DSL path**.
+   (Implemented as `FilterOnlyEmptyPathCollisionTest`; verified failing on HEAD without the fix, green with it. Drives `FlowDslBuilder` per exec-log deviation #1.)
    - Files: new test under
      `flows/adapters/in/gradle/src/test/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/`
      (near `CharpadIntegrationTest.kt`)
@@ -237,8 +238,9 @@ mergeable on its own.
 ### Phase 2: End-to-end verification against tony
 **Goal**: Confirm the real-world harness that surfaced the bug now configures and builds.
 
-1. **Step 2.1**: e2e-test the locally built plugin against tony.
+1. **Step 2.1** — [x] done: e2e-test the locally built plugin against tony.
    - Files: none (verification only) — use the `e2e-test` skill.
+   - Result: tony `./gradlew tasks` and `./gradlew flows` both BUILD SUCCESSFUL; no "produced by multiple flows" error; 68 flow steps ran; representative artifacts present and non-empty.
    - Description: Publish the plugin to mavenLocal as the snapshot and run tony's `flows` (and
      `tasks`) task; confirm configuration completes with no empty-path `FlowValidationException` and
      expected artifacts are produced.
@@ -291,6 +293,7 @@ mergeable on its own.
 |------|------------|---------|
 | 2026-07-19 | AI Agent | Created plan; root cause traced to `CharpadOutputs.getAllOutputPaths` + `FlowDsl.registerStep`. |
 | 2026-07-19 | AI Agent | Accepted. Ran adversarial challenge (mode A) → revised: sharpened Step 1.3 to drive the real DSL path and assert sub-outputs survive; standardised on `isNotEmpty()`; verified `CharpadCommand` non-positional use (risk resolved); pinned Step 1.1 to the `primaryOutputs` sub-list. |
+| 2026-07-19 | AI Agent | Executed all steps (autonomous). Applied both source fixes + `FilterOnlyEmptyPathCollisionTest`; verified test fails on HEAD without fix and passes with it; flows unit tests + Spotless green; tony e2e (`tasks`, `flows`) BUILD SUCCESSFUL with artifacts present. Status → implemented. See [EXEC-0016](EXEC-0016_flows-empty-artifact-path-collision.md) (deviation: test drives `FlowDslBuilder`). |
 
 ---
 

--- a/plans/PLAN-0016_flows-empty-artifact-path-collision.md
+++ b/plans/PLAN-0016_flows-empty-artifact-path-collision.md
@@ -1,0 +1,297 @@
+# Feature: Fix empty-path flow artifact collision blocking all Gradle tasks
+
+**Plan ID**: PLAN-0016
+**Issue**: #181
+**Status**: accepted
+**Challenge**: revised 2026-07-19
+**Created**: 2026-07-19
+**Last Updated**: 2026-07-19
+
+## 1. Feature Description
+
+### Overview
+Every Gradle task in a project that declares two or more flows containing a
+**filter-only Charpad output block** (an `interleaver`/`nybbler` filter with no primary
+`output`) fails at Gradle *configuration time* with:
+
+```
+Flow validation failed: Artifact path '' is produced by multiple flows: 'intro' and 'game'
+```
+
+Because flow validation runs across **all** declared flows during configuration, this aborts
+*every* task in the project (`flows`, `flowTitle`, `build`, `asm`, `tasks`, …), not just the
+colliding flows. This is a pre-existing bug (confirmed at `develop` HEAD `f30f9b4`, before
+#176) that blocks the tony harness project from building at all.
+
+### Requirements
+- A filter-only output block (no primary `output`, only `interleaver`/`nybbler` sub-outputs) must
+  **not** register an empty-string (`''`) artifact for dependency tracking.
+- Two flows each containing such a block must configure and build without a spurious
+  "produced by multiple flows" collision on the empty path.
+- The filter's real sub-output paths must still be tracked as produced artifacts (no regression in
+  dependency detection or incremental-build wiring).
+- The fix must be robust at the artifact-registration choke point so that an empty path from **any**
+  present or future step type cannot poison flow validation.
+
+### Success Criteria
+- The tony project (`C:/Users/maciek/prj/cbm/tony`) runs `./gradlew flows` (and `tasks`) to
+  configuration completion without the empty-path collision.
+- A new regression test reproduces the two-flow empty-path scenario and passes with the fix.
+- `./gradlew :flows:test` and `./gradlew :flows:adapters:in:gradle:test` pass.
+- No existing flows test regresses.
+
+## 2. Root Cause Analysis
+
+The empty-path artifact originates from the Charpad output model and is registered without
+filtering, then rejected by cross-flow validation.
+
+### Current State
+The failure is a three-link chain:
+
+1. **Empty primary output is a legitimate domain state.** `CharpadStepBuilder` intentionally
+   supports *filter-only* output blocks — a `charset`/`tiles`/`map` block that specifies only an
+   `interleaver`/`nybbler` filter and no primary `output`. The guards admit these:
+   `flows/adapters/in/gradle/src/main/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/dsl/CharpadStepBuilder.kt:83`
+   (and the parallel guards at lines 92, 102, 112, 122, 132, 141, 151, 161, 173) add the output when
+   `builder.output.isNotEmpty() || builder.filter != FilterConfig.None`. So `CharsetOutput("")`,
+   `TileOutput("")`, `MapOutput("")` with a real filter are valid. Additionally, `meta {}`
+   (`CharpadStepBuilder.kt:186`) adds its `MetadataOutput` **unconditionally** (no output guard at
+   all), so an empty `meta {}` output is a second way an empty primary output enters the Charpad
+   model.
+
+2. **`getAllOutputPaths()` leaks the empty primary output.**
+   `flows/src/main/kotlin/com/github/c64lib/rbt/flows/domain/config/CharpadOutputs.kt:182`
+   builds `primaryOutputs` by mapping every block to its `.output` **unconditionally**
+   (lines 183–194), then appends the filter sub-outputs (`rangeFilterOutputs`, `mapFilterOutputs`,
+   lines 196–221). A filter-only block therefore contributes `""` to `primaryOutputs` while its real
+   files come from the filter outputs. `CharpadStep.outputs` is exactly this list
+   (`flows/src/main/kotlin/com/github/c64lib/rbt/flows/domain/steps/CharpadStep.kt:48`), so
+   `CharpadStep.outputs` contains `""`.
+
+3. **`registerStep` turns every output into an artifact with no empty-filtering.**
+   `flows/adapters/in/gradle/src/main/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/FlowDsl.kt:279`
+   iterates `step.outputs` and creates `FlowArtifact("${stepName}_output_${i}", output)` for each —
+   including the `""`. The builder's `build()` then sets `produces = outputs`
+   (`FlowDsl.kt:289`).
+
+4. **Validation rejects the shared empty path.**
+   `flows/src/main/kotlin/com/github/c64lib/rbt/flows/domain/FlowDependencyGraph.kt:49`–`56`
+   records the producer of each `artifact.path`; the second flow to declare a `''`-path artifact
+   trips `throw FlowValidationException("Artifact path '' is produced by multiple flows: …")`.
+
+In the tony project, both the `intro` flow and the `game` flow contain filter-only Charpad blocks
+(e.g. `tiles { interleaver { outputs = listOf(...) } }` in `build.gradle.kts`), so each registers a
+`''` produced artifact and they collide.
+
+**Precedent for the fix already exists:** the Gradle output-wiring path already discards empty
+paths — `FlowTasksGenerator.kt:325` uses `step.outputs.filter { it.isNotEmpty() }.map { project.file(it) }`.
+The bug is that `registerStep`'s artifact registration (and, more fundamentally,
+`getAllOutputPaths()`) does not.
+
+### Desired State
+Empty output paths never become tracked `FlowArtifact`s. Filter-only Charpad blocks are tracked by
+their real filter sub-output paths only; two flows using them configure and build cleanly. The
+empty-path guard sits at the registration choke point so no step type can reintroduce the bug.
+
+### Gap Analysis
+- Stop empty strings from becoming `FlowArtifact`s in `FlowDsl.registerStep` (choke-point fix —
+  covers inputs and outputs for **all** step types).
+- Additionally stop `CharpadOutputs.getAllOutputPaths()` from emitting the empty primary output of a
+  filter-only block (source fix — keeps `CharpadStep.outputs`, `hasOutputs()`, Gradle output wiring,
+  and any other consumer clean, not just artifact registration).
+- Add regression coverage at both the unit level (the two config helpers) and the integration level
+  (two flows with filter-only blocks pass validation).
+
+## 3. Relevant Code Parts
+
+### Existing Components
+- **CharpadOutputs.getAllOutputPaths()**: emits the empty primary `.output` of filter-only blocks.
+  - Location: `flows/src/main/kotlin/com/github/c64lib/rbt/flows/domain/config/CharpadOutputs.kt:182`
+  - Integration Point: feeds `CharpadStep.outputs` (CharpadStep.kt:48) and `hasOutputs()` (line 227).
+- **FlowDsl.registerStep()**: registers a `FlowArtifact` per input/output with no empty filtering.
+  - Location: `flows/adapters/in/gradle/src/main/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/FlowDsl.kt:274`
+  - Integration Point: `build()` sets `produces`/`consumes` from these artifacts (FlowDsl.kt:284).
+- **FlowDependencyGraph.addFlow()**: throws on cross-flow duplicate produced paths (incl. `''`).
+  - Location: `flows/src/main/kotlin/com/github/c64lib/rbt/flows/domain/FlowDependencyGraph.kt:49`
+- **FlowTasksGenerator**: already filters empty output paths for Gradle wiring — the precedent.
+  - Location: `flows/adapters/in/gradle/src/main/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/FlowTasksGenerator.kt:325`
+- **CharpadStepBuilder**: intentionally allows filter-only output blocks (the legitimate source of
+  the empty primary output).
+  - Location: `flows/adapters/in/gradle/src/main/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/dsl/CharpadStepBuilder.kt:83`
+- **ImageStepBuilder / SpritepadOutputs** (scope boundary — not buggy):
+  `ImageStepBuilder` guards empty outputs at the builder (`ImageStepBuilder.kt:169,182`), and
+  `SpritepadOutputs` has no filter blocks (`SpritepadOutputs.kt:59`). The choke-point fix protects
+  them regardless, but neither is a current trigger.
+
+### Architecture Alignment
+- **Domain**: `flows` (config + domain step model) and its inbound Gradle adapter (`flows/adapters/in/gradle`).
+- **Use Cases**: none changed — this is a data-modelling/registration defect, not a use-case change.
+- **Ports**: none.
+- **Adapters**: inbound Gradle DSL (`FlowDsl`). No outbound adapter changes.
+- Consistent with the existing `FlowTasksGenerator.kt:325` empty-path filtering convention.
+
+### Dependencies
+- None new. Test frameworks already present (Kotest/JUnit in the flows modules).
+
+## 4. Questions and Clarifications
+
+### Self-Reflection Questions
+- **Q**: Which step type produces the empty path in tony?
+  - **A**: Charpad. Both `intro` and `game` use filter-only Charpad blocks
+    (`tiles { interleaver { … } }`), each emitting a `''` primary output.
+- **Q**: Are Image and Spritepad also affected?
+  - **A**: Not currently. `ImageStepBuilder` guards empty outputs at the builder (lines 169, 182);
+    `SpritepadStepBuilder` guards `sprites {}` (line 64) and has no filter concept. The choke-point
+    fix still protects them defensively.
+- **Q**: Which step types can synthesize an empty path today?
+  - **A**: Only **Charpad** synthesizes one on its own — via filter-only `charset`/`tiles`/`map`
+    (etc.) blocks and via unguarded `meta {}`. Goattracker/command/assemble/dasm/exomizer pass output
+    strings through verbatim, so they are only vulnerable if the build script literally writes
+    `to("")`; they never synthesize an empty path. Image, Spritepad, and Test cannot produce one.
+    The `registerStep` choke-point fix covers all of these uniformly (inputs and outputs).
+- **Q**: Should the fix be at validation, registration, or the source model?
+  - **A**: Both registration (choke point — defends all step types) and the Charpad source model
+    (keeps `CharpadStep.outputs`/`hasOutputs()`/Gradle wiring correct). Not at
+    `FlowDependencyGraph` validation — an empty produced path is meaningless and should never reach
+    validation, so filtering there would only mask the defect.
+- **Q**: Could filtering empty outputs hide a genuinely under-configured step (a real block that
+  forgot its output)?
+  - **A**: No. A block with neither a primary `output` nor a filter is already dropped by the
+    builder guards, so an empty primary output only ever coexists with a real filter that supplies
+    the actual paths. `hasOutputs()` remains true via the filter sub-outputs.
+
+### Unresolved Questions
+{none}
+
+### Design Decisions
+- **Decision**: Where to filter empty paths.
+  - **Options**: (A) `FlowDsl.registerStep` only; (B) `CharpadOutputs.getAllOutputPaths` only;
+    (C) both.
+  - **Recommendation**: **C**. `registerStep` is the choke point that fixes the reported crash for
+    every step type; fixing `getAllOutputPaths` additionally keeps the domain `CharpadStep.outputs`
+    list clean for all its other consumers (Gradle output wiring, logging, incremental build).
+    Belt-and-suspenders, each justified independently.
+
+### Adversarial Challenge
+- **Status**: revised 2026-07-19 (mode A, run at acceptance)
+- **Findings**: Verdict was *sound with caveats* — diagnosis and fix correct; caveats about test
+  fidelity and one unverified regression surface. Addressed:
+  - **Test could pass vacuously (medium).** Original Step 1.3 could hand-build `Flow.produces` and
+    bypass `registerStep`, the exact site the empty path is born. → Step 1.3 rewritten to drive the
+    real DSL builder → `build()` → `FlowDependencyGraph` path, and to fail on `develop` HEAD first.
+  - **Over-filtering could silently drop real outputs (gap).** → Steps 1.1 and 1.3 now assert the
+    filter sub-outputs *survive*, not just that `''` is gone.
+  - **Positional-coupling regression risk (medium).** → Verified: `CharpadCommand.getAllOutputFiles()`
+    (CharpadCommand.kt:44) maps over `getAllOutputPaths()` with no index zip; filtering is safe and
+    removes a latent bogus "project-root" output. Risk downgraded to resolved.
+  - **`isNotBlank()` vs `isNotEmpty()` inconsistency (low).** → Standardised on `isNotEmpty()` to
+    match the `FlowTasksGenerator.kt:325` precedent.
+  - **Which list to filter (hidden assumption).** → Step 1.1 pins the filter to the `primaryOutputs`
+    sub-list only, preserving `hasOutputs()`.
+
+## 5. Implementation Plan
+
+### Phase 1: Source fix + regression tests (mergeable fix)
+**Goal**: Empty output paths never enter `CharpadStep.outputs` or the flow artifact registry;
+regression tests lock the behaviour in.
+
+1. **Step 1.1**: Filter empty primary outputs in `CharpadOutputs.getAllOutputPaths()`.
+   - Files: `flows/src/main/kotlin/com/github/c64lib/rbt/flows/domain/config/CharpadOutputs.kt`
+   - Description: Apply `.filter { it.isNotEmpty() }` to the **`primaryOutputs` sub-list only**
+     (CharpadOutputs.kt:183–194), leaving `rangeFilterOutputs`/`mapFilterOutputs` untouched. Use
+     `isNotEmpty()` (not `isNotBlank()`) to match the existing repo precedent at
+     `FlowTasksGenerator.kt:325`. Because the filter sub-outputs are unaffected, `hasOutputs()`
+     stays true for filter-only blocks. (Confirmed no positional coupling: the only consumer,
+     `CharpadCommand.getAllOutputFiles()` at CharpadCommand.kt:44, maps over the list independently
+     with no index zip — filtering the empty entry also removes a latent bogus "project-root" output
+     file, a strict improvement.)
+   - Testing: Unit test — a `CharpadOutputs` with a filter-only `tiles`/`map` block returns only the
+     filter sub-output paths, no `""`; **assert the real filter sub-outputs are still present**; and
+     `hasOutputs()` stays true. Add a case for an empty `meta {}` output (unguarded builder path).
+
+2. **Step 1.2**: Filter empty paths at the artifact-registration choke point in `FlowDsl.registerStep()`.
+   - Files: `flows/adapters/in/gradle/src/main/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/FlowDsl.kt`
+   - Description: In `registerStep`, skip blank entries when building input/output `FlowArtifact`s
+     (guard the `step.inputs`/`step.outputs` iterations at lines 276–281 with `isNotEmpty()`).
+     Defensive against any step type, mirroring `FlowTasksGenerator.kt:325`.
+   - Testing: Unit test — a step whose `outputs` (and `inputs`) contain `""` registers no empty-path
+     artifact.
+
+3. **Step 1.3**: Integration regression test for the two-flow collision — **through the real DSL path**.
+   - Files: new test under
+     `flows/adapters/in/gradle/src/test/kotlin/com/github/c64lib/rbt/flows/adapters/in/gradle/`
+     (near `CharpadIntegrationTest.kt`)
+   - Description: Build two flows via the **DSL builder** — each containing a `charpadStep` with a
+     filter-only block (e.g. `tiles { interleaver { outputs = listOf(...) } }`, no primary `output`)
+     — call `build()` so `registerStep` runs, add both flows to a `FlowDependencyGraph`, and assert
+     `addFlow`/`validate()` do **not** throw the empty-path `FlowValidationException`. Additionally
+     assert the flows' `produces` contain the real filter sub-output paths and **no empty-path
+     artifact**. Do NOT hand-build `Flow.produces` — the test must exercise the DSL→build→graph path
+     where the empty path is actually born, or it can pass vacuously. This is the direct #181
+     reproduction: it must fail on `develop` HEAD and pass after Steps 1.1–1.2.
+   - Testing: Run on `develop` HEAD first to confirm it reproduces, then confirm green after the fix.
+
+**Phase 1 Deliverable**: The empty-path collision is fixed and covered by unit + integration tests;
+mergeable on its own.
+
+### Phase 2: End-to-end verification against tony
+**Goal**: Confirm the real-world harness that surfaced the bug now configures and builds.
+
+1. **Step 2.1**: e2e-test the locally built plugin against tony.
+   - Files: none (verification only) — use the `e2e-test` skill.
+   - Description: Publish the plugin to mavenLocal as the snapshot and run tony's `flows` (and
+     `tasks`) task; confirm configuration completes with no empty-path `FlowValidationException` and
+     expected artifacts are produced.
+   - Testing: `./gradlew tasks` / `./gradlew flows` on tony reach configuration completion.
+
+**Phase 2 Deliverable**: Verified fix against the originating project; ready to ship.
+
+## 6. Testing Strategy
+
+### Unit Tests
+- `CharpadOutputs.getAllOutputPaths()`: filter-only block yields only real sub-output paths, no `""`;
+  `hasOutputs()` remains true.
+- `FlowDsl.registerStep`: a step output list containing `""` produces no empty-path `FlowArtifact`.
+
+### Integration Tests
+- Two flows with filter-only Charpad blocks pass `FlowDependencyGraph.addFlow`/`validate()` without
+  the empty-path collision (direct #181 reproduction).
+
+### Manual Testing
+- Run `e2e-test` (or manually `./gradlew flows` in tony) and confirm the build configures past the
+  previously fatal validation error.
+
+## 7. Risks and Mitigation
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| Filtering empty outputs hides a genuinely mis-configured block | Medium | Low | Builder guards already drop no-output/no-filter blocks; an empty primary output only appears alongside a real filter. `hasOutputs()` still validates configuration presence. |
+| Downstream consumer relies on positional index of `getAllOutputPaths()` including the empty slot | Low | Low | **Resolved** — verified `CharpadCommand.getAllOutputFiles()` (CharpadCommand.kt:44) maps over the list independently with no index zip; filtering the empty entry removes a latent bogus "project-root" output file. |
+| Fixing only one of the two sites leaves latent bug | Medium | Low | Apply both fixes (Steps 1.1 + 1.2) and cover with integration test at the graph level. |
+
+## 8. Documentation Updates
+
+- [ ] No README change expected (behavioural bugfix, no DSL surface change).
+- [ ] Consider a brief note in `doc/arc42/08_crosscutting_concepts.md` if the empty-path filtering
+      becomes a documented cross-cutting rule (optional).
+- [ ] Add concise inline comments at both fix sites explaining why empty paths are dropped
+      (filter-only outputs), referencing the `FlowTasksGenerator.kt:325` precedent.
+- [ ] Update CLAUDE.md only if a new pattern warrants it (likely not).
+
+## 9. Rollout Plan
+
+1. Ship in Phase 1 as a self-contained bugfix on a feature branch → PR into `develop`.
+2. Verify against tony (Phase 2) before merge; watch for any flows integration-test regressions.
+3. Rollback strategy: revert the two small edits — they are isolated to `CharpadOutputs.kt` and
+   `FlowDsl.kt` with no API or schema change.
+
+## 10. Revision History
+
+| Date | Updated By | Changes |
+|------|------------|---------|
+| 2026-07-19 | AI Agent | Created plan; root cause traced to `CharpadOutputs.getAllOutputPaths` + `FlowDsl.registerStep`. |
+| 2026-07-19 | AI Agent | Accepted. Ran adversarial challenge (mode A) → revised: sharpened Step 1.3 to drive the real DSL path and assert sub-outputs survive; standardised on `isNotEmpty()`; verified `CharpadCommand` non-positional use (risk resolved); pinned Step 1.1 to the `primaryOutputs` sub-list. |
+
+---
+
+**Note**: This plan should be reviewed and approved before implementation begins.

--- a/plans/README.md
+++ b/plans/README.md
@@ -20,3 +20,4 @@ Plans are permanent artifacts — do not delete. Terminal plans (`implemented`, 
 | [PLAN-0013](PLAN-0013_teststep-stale-spec-results.md) | 2026-07-18 | implemented | Fix stale pass/fail results in testStep when derived artifacts already exist | #175 | [EXEC-0013](EXEC-0013_teststep-stale-spec-results.md) |
 | [PLAN-0014](PLAN-0014_adversarial-challenge-at-acceptance.md) | 2026-07-19 | implemented | Move adversarial challenge to plan acceptance | #186 | [EXEC-0014](EXEC-0014_adversarial-challenge-at-acceptance.md) |
 | [PLAN-0015](PLAN-0015_flows-groovy-usefrom-useto-nested-closure.md) | 2026-07-19 | implemented | Fix useFrom()/useTo() in Groovy nested commandStep closures | #182 | [EXEC-0015](EXEC-0015_flows-groovy-usefrom-useto-nested-closure.md) |
+| [PLAN-0016](PLAN-0016_flows-empty-artifact-path-collision.md) | 2026-07-19 | accepted | Fix empty-path flow artifact collision blocking all Gradle tasks | #181 | — |

--- a/plans/README.md
+++ b/plans/README.md
@@ -20,4 +20,4 @@ Plans are permanent artifacts — do not delete. Terminal plans (`implemented`, 
 | [PLAN-0013](PLAN-0013_teststep-stale-spec-results.md) | 2026-07-18 | implemented | Fix stale pass/fail results in testStep when derived artifacts already exist | #175 | [EXEC-0013](EXEC-0013_teststep-stale-spec-results.md) |
 | [PLAN-0014](PLAN-0014_adversarial-challenge-at-acceptance.md) | 2026-07-19 | implemented | Move adversarial challenge to plan acceptance | #186 | [EXEC-0014](EXEC-0014_adversarial-challenge-at-acceptance.md) |
 | [PLAN-0015](PLAN-0015_flows-groovy-usefrom-useto-nested-closure.md) | 2026-07-19 | implemented | Fix useFrom()/useTo() in Groovy nested commandStep closures | #182 | [EXEC-0015](EXEC-0015_flows-groovy-usefrom-useto-nested-closure.md) |
-| [PLAN-0016](PLAN-0016_flows-empty-artifact-path-collision.md) | 2026-07-19 | accepted | Fix empty-path flow artifact collision blocking all Gradle tasks | #181 | — |
+| [PLAN-0016](PLAN-0016_flows-empty-artifact-path-collision.md) | 2026-07-19 | implemented | Fix empty-path flow artifact collision blocking all Gradle tasks | #181 | [EXEC-0016](EXEC-0016_flows-empty-artifact-path-collision.md) |


### PR DESCRIPTION
## Summary

Fixes #181: a filter-only Charpad output block (an `interleaver`/`nybbler` filter with no primary `output`) — and an empty `meta {}` — carried an empty primary output path. That empty string leaked into `CharpadOutputs.getAllOutputPaths()` and was registered as a `''` `FlowArtifact` in `FlowDsl.registerStep()`, so two flows each using such a block collided during flow validation ("Artifact path '' is produced by multiple flows: 'intro' and 'game'"), aborting **every** Gradle task at configuration time.

## Changes

- **`CharpadOutputs.getAllOutputPaths()`** — filter empty entries out of the primary-outputs sub-list with `isNotEmpty()`; the real interleaver/nybbler sub-outputs are unaffected, so `hasOutputs()` stays correct.
- **`FlowDsl.registerStep()`** — skip empty input/output paths at the artifact-registration choke point (defends every step type), mirroring the existing empty-path filtering in `FlowTasksGenerator`.
- **`FilterOnlyEmptyPathCollisionTest`** — new regression test driving the real DSL → `FlowDslBuilder.build()` → `FlowService.validateFlows` path; verified to fail without the fix and pass with it.

## Verification

- `:flows:test` and `:flows:adapters:in:gradle:test` green; Spotless clean.
- Regression test confirmed failing on branch HEAD without the fix, passing with it.
- End-to-end against the tony harness: `./gradlew tasks` and `./gradlew flows` both BUILD SUCCESSFUL (no "produced by multiple flows" error; 68 flow steps ran; expected artifacts present and non-empty).

See PLAN-0016 / EXEC-0016 for the full plan and execution log.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)